### PR TITLE
feat(compression): change gzip to brotli

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -65,3 +65,14 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'eu-west-1'
         SOURCE_DIR: './'
+
+    - name: S3 Sync Brotli
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --exclude '*' --include 'main-latest.js' --acl 'public-read' --content-type application/javascript --content-encoding br --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'eu-west-1'
+        SOURCE_DIR: './'

--- a/index-build.html
+++ b/index-build.html
@@ -21,6 +21,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="text/javascript" src="./main-latest.js"></script>
+    <script type="module" src="main-latest.js"></script>
+    <script nomodule src="fallback.js"></script>
   </body>
 </html>

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,5 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
+const zlib = require("zlib")
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const path = require('path')
 const { readdirSync } = require('fs')
@@ -60,7 +61,12 @@ const createConfigs = () => {
                 new CompressionPlugin({
                     filename: '[path]',
                     test: /\.js$/,
-                    algorithm: 'gzip',
+                    algorithm: "brotliCompress",
+                    compressionOptions: {
+                      params: {
+                        [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+                      },
+                    },
                     deleteOriginalAssets: false
                 }),
                 new HtmlWebpackPlugin({


### PR DESCRIPTION
### Description
Changed compression algorithm to use Brotli to reduce the overall bundle size

To test... ( compare )

Build master and see dist folder for a map.. approx. 1mb
Pull branch, and run "npm run build" again, to recheck dist folder for that map solution.. approx. 800kb

Roughly saving 200kb on current map application bundles

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary