### PR TITLE
feat(Popup): Add original popup if not included in reduced content

### DIFF
--- a/Configuration/election/Popups/index.js
+++ b/Configuration/election/Popups/index.js
@@ -1,0 +1,46 @@
+const wardPopup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+    <div class="smbc-map__item__header__block">
+      <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+      <span class="smbc-map__item__header__block__title">Ward</span>
+    </div>
+      <div class="smbc-map__item__body">
+      <p>Name: ${feature.properties.ward_name}</p>
+    </div>
+  </div>`
+  layer.bindPopup(content)
+}
+
+const polling_districtsPopup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+    <div class="smbc-map__item__header__block">
+      <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+      <span class="smbc-map__item__header__block__title">Polling District</span>
+    </div>
+      <div class="smbc-map__item__body">
+        <p>Name: ${feature.properties.polling_name}</p>
+    </div>
+  </div>`
+
+  layer.bindPopup(content)
+}
+
+const polling_stationsPopup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+    <div class="smbc-map__item__header__block">
+      <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+      <span class="smbc-map__item__header__block__title">Polling Station</span>
+    </div>
+      <div class="smbc-map__item__body">
+        <p> Polling Station No: ${feature.properties.station_no}</p>
+        <p>Address: ${feature.properties.address}</p>
+    </div>
+  </div>`
+  layer.bindPopup(content)
+}
+
+export {
+  wardPopup,
+  polling_districtsPopup,
+  polling_stationsPopup
+}

--- a/Configuration/election/Styles/index.js
+++ b/Configuration/election/Styles/index.js
@@ -1,0 +1,30 @@
+const wardStyle = {
+    color: '#a6cee3',
+    weight:5,
+    opacity:0.75,
+    fillColor: '#a6cee3',
+    fillOpacity:0
+}
+
+const polling_districtsStyle = {
+    color: '#1f78b4',
+    weight:3,
+    opacity:1,
+    fillColor: '#ccebc5',
+    fillOpacity:0
+}
+
+const polling_stationStyle = {
+    radius: 6,
+    color: '#000',
+    weight:2,
+    opacity:1,
+    fillColor: '#cab2d6',
+    fillOpacity:1
+}
+
+export {
+    wardStyle,
+    polling_districtsStyle,
+    polling_stationStyle
+}

--- a/Configuration/election/index.js
+++ b/Configuration/election/index.js
@@ -1,0 +1,51 @@
+import Leaflet from 'leaflet'
+import { wardStyle, polling_districtsStyle, polling_stationStyle } from './Styles'
+import { wardPopup, polling_districtsPopup, polling_stationsPopup } from './Popups'
+
+export default {
+    Map: {
+        MapClickMinZoom: 16
+    },
+    Tiles: {
+        Token: 'pk.eyJ1IjoiZ2lzLXN0b2NrcG9ydCIsImEiOiJja29jdWJ4MHIwMnczMnZsNHRtaWJkeHc2In0.W3-zhdnDhpyNX0AubRT--g'
+    },
+    DynamicData:
+        [
+            {
+                key: 'Polling Districts',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=political:polling_districts&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: polling_districtsPopup,
+                    maxZoom: 2,
+                    style: polling_districtsStyle
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+            {
+                key: 'Ward',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=political:ward&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: wardPopup,
+                    maxZoom: 2,
+                    style: wardStyle
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+            {
+                key: 'Polling Stations',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=political:polling_stations_4326&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: polling_stationsPopup,
+                    maxZoom: 2,
+                    style: polling_stationStyle,
+                    pointToLayer: (feature, latlng) => {
+                        return Leaflet.circleMarker(latlng)
+                    }
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+        ]
+}

--- a/Configuration/historic-environment/Popups/index.js
+++ b/Configuration/historic-environment/Popups/index.js
@@ -1,0 +1,110 @@
+const Locally_listed_Popup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Locally Listed Building</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${feature.properties.name}</p>
+    <p>Type: ${feature.properties.type}</p>
+    <p>Committee: ${feature.properties.committee}</p>
+    <p>Ward: ${feature.properties.ward}</p>
+    <a href="${feature.properties.web_db_link}" target="_blank">Further Information</a>
+    </div></div>`
+  layer.bindPopup(content)
+}
+
+const Statutory_listed_Popup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Statutory Listed Building</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${feature.properties.name}</p>
+    <p>Type: ${feature.properties.type}</p>
+    <p>Grade: ${feature.properties.grade}</p>
+    <p>Committee: ${feature.properties.committee}</p>
+    <p>Ward: ${feature.properties.ward}</p>
+    <a href="${feature.properties.web_db_link}" target="_blank"> Further Information</a>
+    </div></div>`
+  layer.bindPopup(content)
+}
+
+const Conservation_area_Popup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-tag smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Conservation Area</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${feature.properties.cons_area}</p>
+    <a href="${feature.properties.web_info_link}" target="_blank">Further Information</a>
+    </div></div>`
+  layer.bindPopup(content)
+}
+
+const Article4_1_direction_Popup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Article 4-1 Direction</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${feature.properties.conservation_area}</p>
+    <p>Type: ${feature.properties.type}</p>
+    <a href="${feature.properties.web_db_link}" target="_blank">Further Information</a>
+    </div></div>`
+  layer.bindPopup(content)
+}
+
+const Article4_2_direction_Popup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Article 4-2 Direction</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${feature.properties.conservation_area}</p>
+    <p>Type: ${feature.properties.type}</p>
+    <a href="${feature.properties.web_db_link}" target="_blank">Further Information</a>
+    </div></div>`
+  layer.bindPopup(content)
+}
+
+const Scheduled_monument_Popup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-university smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Scheduled Monument</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${feature.properties.name}</p>
+    <p>National Monument No: ${feature.properties.national_monument_no}</p>
+    <p>${feature.properties.web_db_link}</p>
+    </div></div>`
+  layer.bindPopup(content)
+}
+
+const Historic_Parks_Gardens_Popup = (feature, layer) => {
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-tree smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Registered Historic Park or Garden</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${feature.properties.site}</p>
+    <p>${feature.properties.web_db_link}</p>
+    </div></div>`
+  layer.bindPopup(content)
+}
+
+export {
+  Locally_listed_Popup,
+  Statutory_listed_Popup,
+  Conservation_area_Popup,
+  Article4_1_direction_Popup,
+  Article4_2_direction_Popup,
+  Scheduled_monument_Popup,
+  Historic_Parks_Gardens_Popup
+}

--- a/Configuration/historic-environment/Styles/index.js
+++ b/Configuration/historic-environment/Styles/index.js
@@ -1,0 +1,95 @@
+const Locally_listed_style = {
+    color: '#fb9a99',
+    weight: 2,
+    opacity: 1,
+    fillColor: '#fb9a99',
+    fillOpacity: 0.5
+}
+
+const Statutory_listed_style = {
+color: '#3288bd',
+weight: 2,
+opacity: 1,
+fillColor: '#3288bd',
+fillOpacity: 0.5
+}
+
+const Conservation_area_style = {
+color: '#e31a1c',
+weight: 4,
+opacity: 1,
+fillColor: '#e31a1c',
+fillOpacity: 0
+}
+
+const Article4_1_direction_style = {
+color: '#cab2d6',
+weight: 2,
+opacity: 1,
+fillColor: '#cab2d6',
+fillOpacity: 0.5
+}
+
+const Article4_2_direction_style = {
+color: '#ffff99',
+weight: 2,
+opacity: 1,
+fillColor: '#ffff99',
+fillOpacity: 0.5
+}
+
+const Scheduled_monument_style = {
+color: '#b15928',
+weight: 2,
+opacity: 1,
+fillColor: '#b15928',
+fillOpacity: 0.5
+}
+
+const Historic_parks_gardens_style = {
+color: '#33a02c',
+weight: 2,
+opacity: 1,
+fillColor: '#33a02c',
+fillOpacity: 0.5
+}
+
+const statutorylistedpointsStyle = {
+radius: 4,
+color: '#3288bd',
+weight: 2,
+opacity: 1,
+fillColor: '#3288bd',
+fillOpacity: 0.5
+}
+
+const locallylistedpointsStyle = {
+radius: 4,
+color: '#fb9a99',
+weight: 2,
+opacity: 1,
+fillColor: '#fb9a99',
+fillOpacity: 0.5
+}
+
+const Scheduled_monument_points_style = {
+radius: 4,
+color: '#b15928',
+weight: 2,
+opacity: 1,
+fillColor: '#b15928',
+fillOpacity: 0.5
+}
+
+export {
+Locally_listed_style,
+Statutory_listed_style,
+Conservation_area_style,
+Article4_1_direction_style,
+Article4_2_direction_style,
+Scheduled_monument_style,
+Historic_parks_gardens_style,
+statutorylistedpointsStyle,
+locallylistedpointsStyle,
+Scheduled_monument_points_style
+}

--- a/Configuration/historic-environment/index.js
+++ b/Configuration/historic-environment/index.js
@@ -1,0 +1,143 @@
+import Leaflet from 'leaflet'
+import { Locally_listed_Popup, Statutory_listed_Popup, Conservation_area_Popup, Article4_1_direction_Popup, Article4_2_direction_Popup, Scheduled_monument_Popup, Historic_Parks_Gardens_Popup } from './Popups'
+import { Locally_listed_style, Statutory_listed_style, Conservation_area_style, Article4_1_direction_style, Article4_2_direction_style, Scheduled_monument_style, Historic_parks_gardens_style, statutorylistedpointsStyle, locallylistedpointsStyle, Scheduled_monument_points_style } from './Styles'
+
+export default {
+    Map: {
+        MapClickMinZoom: 16
+    },
+    Tiles: {
+        Token: 'pk.eyJ1IjoiZ2lzLXN0b2NrcG9ydCIsImEiOiJja29jdWJ4MHIwMnczMnZsNHRtaWJkeHc2In0.W3-zhdnDhpyNX0AubRT--g'
+    },
+    DynamicData:
+        [
+            {
+                key: 'Article 4-1 Direction',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:article_4_1&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Article4_1_direction_Popup,
+                    maxZoom: 2,
+                    style: Article4_1_direction_style
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+            {
+                key: 'Article 4-2 Direction',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:article_4_2&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Article4_2_direction_Popup,
+                    maxZoom: 2,
+                    style: Article4_2_direction_style
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+            {
+                key: 'Conservation Area',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:conservation_area&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Conservation_area_Popup,
+                    maxZoom: 2,
+                    style: Conservation_area_style
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+            {
+                key: 'Registered Historic Park or Garden',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:parkgarden_of_historic_interest&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Historic_Parks_Gardens_Popup,
+                    maxZoom: 2,
+                    style: Historic_parks_gardens_style
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+            {
+                key: 'Scheduled Monument',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:ancient_monument&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Scheduled_monument_Popup,
+                    maxZoom: 17,
+                    minZoom: 20,
+                    style: Scheduled_monument_style
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+            {
+                key: 'Scheduled Monument', //points - seems to work based on the code in app.js identifying layers by zoom level. Having to layers with the same key names is usually a problem.
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:ancient_monument_points&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Scheduled_monument_Popup,
+                    minZoom: 16,
+                    maxZoom: 2,
+                    style: Scheduled_monument_points_style,
+                    pointToLayer: (feature, latlng) => {
+                        return Leaflet.circleMarker(latlng)
+                    },
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+            {
+                key: 'Locally Listed Building',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:locally_listed_buildings&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Locally_listed_Popup,
+                    maxZoom: 17,
+                    minZoom: 20,
+                    style: Locally_listed_style
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+
+            {
+                key: 'Locally Listed Building', //points - seems to work based on the code in app.js identifying layers by zoom level. Having to layers with the same key names is usually a problem.
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:locally_listed_building_points&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Locally_listed_Popup,
+                    minZoom: 16,
+                    maxZoom: 2,
+                    style: locallylistedpointsStyle,
+                    pointToLayer: (feature, latlng) => {
+                        return Leaflet.circleMarker(latlng)
+                    },
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+
+            {
+                key: 'Statutory Listed Building',
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:statutory_listed_buildings&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Statutory_listed_Popup,
+                    maxZoom: 17,
+                    minZoom: 20,
+                    style: Statutory_listed_style
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+
+            {
+                key: 'Statutory Listed Building', //Points
+                url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:statutory_listed_buildings_points&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+                layerOptions: {
+                    onEachFeature: Statutory_listed_Popup,
+                    minZoom: 16,
+                    maxZoom: 2,
+                    style: statutorylistedpointsStyle,
+                    pointToLayer: (feature, latlng) => {
+                        return Leaflet.circleMarker(latlng)
+                    },
+                },
+                displayOverlay: true,
+                visibleByDefault: true
+            },
+        ]
+}

--- a/src/App.js
+++ b/src/App.js
@@ -87,15 +87,18 @@ function App() {
 
   const [onClickLatLng, setOnClickLatLng] = useState()
   useEffect(() => {
-    if (!onClickLatLng) return
-
+    if (!onClickLatLng || !mapRef.current._popup) return
+    const { _popup } = mapRef.current;
     const polygonsFoundInMap = leafletPip.pointInLayer(onClickLatLng, mapRef.current)
 
-    const layerContentInMap = polygonsFoundInMap
+    let layerContentInMap = polygonsFoundInMap
       .filter(_ => _.feature && _._popup && _._popup._content)
       .reduce((acc, curr, index, src) => {
         return `${acc} ${curr._popup._content} ${index != src.length - 1 ? '<hr/>' : ''}`
       }, '')
+
+      if(layerContentInMap && _popup !== null && _popup._content !== null && !layerContentInMap.includes(_popup._content))
+        layerContentInMap += `<hr/>${_popup._content}`;
 
     /** opens new popup with new content and binds to map, this is instead of using 
      * mapRef.current._popup.setConent as the popup is bound to the layer and not 
@@ -108,7 +111,7 @@ function App() {
     } else {
       Leaflet.popup()
         .setLatLng(onClickLatLng)
-        .setContent(mapRef.current._popup._content)
+        .setContent(_popup._content)
         .openOn(mapRef.current)
     }
     panMap(onClickLatLng)

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,7 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const path = require('path')
 
-const solution = 'mdc'
+const solution = 'election'
 
 module.exports = (env, argv, t) => (
     {


### PR DESCRIPTION
### Description
When clicking on a point layer, the point popup content is not included within the polygonsFoundInMap so some times the point layer popup can not be included if there is other layers found. Added a check to verify if the current mapRef popup content is within the reduced content if not it is added. This had to be checked as a point can turn into a polygon at specific zoom levels so can be included sometimes but not at other zoom levels.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary