### PR TITLE
Sanitised input search

### DIFF
--- a/src/Extensions/Controls/index.js
+++ b/src/Extensions/Controls/index.js
@@ -96,13 +96,8 @@ Leaflet.Control.GroupedLayers = Leaflet.Control.extend({
     var container = this._container = Leaflet.DomUtil.create('div', baseClass)
 
     container.setAttribute('aria-haspopup', true)
-
-    if (Leaflet.Browser.touch) {
-      Leaflet.DomEvent.on(container, 'click', Leaflet.DomEvent.stopPropagation)
-    } else {
-      Leaflet.DomEvent.disableClickPropagation(container)
-      Leaflet.DomEvent.on(container, 'wheel', Leaflet.DomEvent.stopPropagation)
-    }
+    Leaflet.DomEvent.disableClickPropagation(container)
+		Leaflet.DomEvent.disableScrollPropagation(container)
 
     var section = this._section = Leaflet.DomUtil.create('div', `${baseClass}__list`)
 

--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -20,15 +20,15 @@ const fetchWithTimeout = (url, options, timeout = 10000) => {
     ])
 }
 
-const fetchAddressData = (rawSearchTerm, callResponse) =>
-    fetch(`https://spatial.stockport.gov.uk/geoserver/wfs?request=getfeature&outputformat=json&typename=address:llpg_points&cql_filter=address%20ilike%27%25${rawSearchTerm}%25%27`)
-        .then(res => res.clone().json())
+const fetchAddressData = (rawSearchTerm, callResponse) => 
+    fetch(`https://spatial.stockport.gov.uk/geoserver/wfs?request=getfeature&outputformat=json&typename=address:llpg_points&cql_filter=address_search%20ilike%27%25${rawSearchTerm}%25%27`)
+    .then(res => res.clone().json())
         .then(response => {
             callResponse(response.features.map(item => {
-                const address = item.properties.address.replace(/\r\n/g, ', ').toUpperCase().trim()
+                const address = item.properties.address.replace(/\r\n/g, ', ').trim()
                 return { 'loc': item.geometry.coordinates.reverse(), 'title': address }
             }))
-        })
+        })    
 
 const getQueryStringParams = query => {
     return query

--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -28,7 +28,7 @@ const fetchAddressData = (rawSearchTerm, callResponse) =>
                 const address = item.properties.address.replace(/\r\n/g, ', ').trim()
                 return { 'loc': item.geometry.coordinates.reverse(), 'title': address }
             }))
-        })    
+        })
 
 const getQueryStringParams = query => {
     return query


### PR DESCRIPTION
### Description
* Strip user input of A-Za-z0-9 and use this to trigger the search and as the search term without changing the actual input value
* Replace the fetch url with the new one provided by GIS
* Remove the toUpperCase on the address results (at the request of GIS)
* Re-implement resizing the search div and search input max-width (fixes input going wider than the screen width on mobile)
* Add call to autoResize on page load to avoid the search bar size changing with the first character typed
* Add blur to input on handleSubmit so that the input shows the address from the start rather than only showing the end when longer than the input
* Fix click and scroll propagation on search and layer controls


### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary