### PR TITLE
fix(6607): change link to div to remove reload

### DIFF
--- a/src/Extensions/Controls/index.js
+++ b/src/Extensions/Controls/index.js
@@ -12,7 +12,7 @@ Leaflet.Control.GroupedLayers = Leaflet.Control.extend({
     collapsed: true,
     position: 'topright',
     autoZIndex: true,
-    groupCheckboxes: false
+    groupCheckboxes: true
   },
 
   initialize: function (baseLayers, overlays, options) {
@@ -94,33 +94,22 @@ Leaflet.Control.GroupedLayers = Leaflet.Control.extend({
 
   _initLayout: function () {
     var container = this._container = Leaflet.DomUtil.create('div', baseClass)
-
+    this.options.collapsed ? this._collapse() : this._expand()
     container.setAttribute('aria-haspopup', true)
     Leaflet.DomEvent.disableClickPropagation(container)
 		Leaflet.DomEvent.disableScrollPropagation(container)
 
-    var section = this._section = Leaflet.DomUtil.create('div', `${baseClass}__list`)
-      
-    if (this.options.collapsed) {
-      var link = this._layersLink = Leaflet.DomUtil.create('a', `${baseClass}__toggle`, container)
-      link.href = '#'
-      link.title = 'Layers'
+    this._openLayersControls = Leaflet.DomUtil.create('div', `${baseClass}__toggle`, container)
+    Leaflet.DomEvent.on(this._openLayersControls, 'click', this._expand, this)
 
-      var closeLink = this._closeLink = Leaflet.DomUtil.create('a', `${baseClass}__list-close-button`, section)
-      closeLink.href = '#'
-      closeLink.title = 'Close'
-      closeLink.innerText = 'X'
-      Leaflet.DomEvent.on(closeLink, 'click', this._collapse, this)
-      this._topseparator = Leaflet.DomUtil.create('div', `${baseClass}__separator`, section)
-      
-      if (Leaflet.Browser.touch) {
-        Leaflet.DomEvent.on(link, 'click', Leaflet.DomEvent.stop).on(link, 'click', this._expand, this)
-        this._map.on('click', this._collapse, this)
-      } else {   
-        Leaflet.DomEvent.on(link, 'click', Leaflet.DomEvent.stop).on(link, 'click', this._expand, this)
-      }
-    } else {
-      this._expand()
+    var section = this._section = Leaflet.DomUtil.create('div', `${baseClass}__list`)
+
+    this._closeLayersControls = Leaflet.DomUtil.create('div', `${baseClass}__list-close-button`, section)
+    this._closeLayersControls.innerText = 'X'
+    Leaflet.DomEvent.on(this._closeLayersControls, 'click', this._collapse, this)
+
+    if (Leaflet.Browser.touch) {
+      this._map.on('click', this._collapse, this)
     }
 
     this._baseLayersList = Leaflet.DomUtil.create('div', `${baseClass}__base`, section)

--- a/src/Extensions/Controls/index.js
+++ b/src/Extensions/Controls/index.js
@@ -12,7 +12,7 @@ Leaflet.Control.GroupedLayers = Leaflet.Control.extend({
     collapsed: true,
     position: 'topright',
     autoZIndex: true,
-    groupCheckboxes: true
+    groupCheckboxes: false
   },
 
   initialize: function (baseLayers, overlays, options) {


### PR DESCRIPTION
### Description
issue came out of QA-ing this [Live Map Link](https://www.stockport.gov.uk/local-land-charges-search/personal-searches)
When you close the layers control, a "#" is appended to the url, and the page is reloaded to the top.

I've removed the href="#", and in fact removed the "open/close button" to be a **(a href="#")** tag... replaced it with a div, as this is not an "accessible" map, I think it's okay.

Simplified the initLayout() function

continued issue is with this change the hover state on the open/close button is an arrow and not a pointer. See [Design System PR](https://github.com/smbc-digital/stockportgov-design-system/pull/112) which ensures the layers controls has a pointer cursor, but also can't highlight the text as this can have a weird effect if lazily trying to open/close.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary