### PR TITLE
refactor(illuminated-assets): add config to have separate maps for si…

### DIFF
--- a/Configuration/illuminated-assets/Popups/index.js
+++ b/Configuration/illuminated-assets/Popups/index.js
@@ -3,22 +3,22 @@ import { getTargetUrl } from '../Helpers'
 const illuminatedsignsActivePopup = feature => {
   
   return `<div class="smbc-map__item">
-  <div class="smbc-map__item__header__block">
-    <i class="fa fa-map-marker smbc-map__item__header__block__icon" aria-hidden="true"></i>
-    <span class="smbc-map__item__header__block__title">Location</span>
+    <div class="smbc-map__item__header__block">
+      <i class="fa fa-map-marker smbc-map__item__header__block__icon" aria-hidden="true"></i>
+      <span class="smbc-map__item__header__block__title">Location</span>
+    </div>
+    <div class="smbc-map__item__body">
+      <p>${feature.properties.location_description}</p>
+    </div>
   </div>
-  <div class="smbc-map__item__body">
-    <p>${feature.properties.location_description}</p>
-  </div>
-</div>
-<div class="smbc-map__item govuk-grid-column-full"> 
+  <div class="smbc-map__item"> 
     <div class="smbc-map__item__header__block">
       <i class="fa fa-tag smbc-map__item__header__block__icon" aria-hidden="true"></i>
       <span class="smbc-map__item__header__block__title">Sign ID</span>
     </div>
     <div class="smbc-map__item__body">
       <p>${feature.properties.feature_id}</p>  
-        <a class="govuk-button govuk-!-margin-bottom-1" href="report-an-issue/fault-type?assetId=${feature.properties.central_asset_id}&siteCode=${feature.properties.site_code}">Report this sign</a>
+        <a class="govuk-button govuk-!-margin-bottom-1 govuk-!-width-full" href="lit-sign/fault-type?assetId=${feature.properties.central_asset_id}&siteCode=${feature.properties.site_code}">Report this sign</a>
     </div>
   </div>`
 }
@@ -48,7 +48,7 @@ const illuminatedsignsFaultPopup = feature => {
    <p>${feature.properties.location_description}</p>
  </div>
 </div>
-<div class="smbc-map__item govuk-grid-column-full">
+<div class="smbc-map__item">
    <div class="smbc-map__item__header__block">
      <i class="fa fa-tag smbc-map__item__header__block__icon" aria-hidden="true"></i>
      <span class="smbc-map__item__header__block__title">Sign ID</span>
@@ -60,7 +60,7 @@ const illuminatedsignsFaultPopup = feature => {
        ${defaultMessage}
        </div>
      </div>
-       <a class="govuk-button govuk-!-margin-bottom-1" href="${varName}/track-a-report/details/${feature.properties.ext_system_ref}">View reported fault</a>
+       <a class="govuk-button govuk-!-margin-bottom-1 govuk-!-width-full" href="${varName}/track-a-report/details/${feature.properties.ext_system_ref}">View reported fault</a>
      ${showLastUpdated}
    </div>
    </div>`
@@ -125,14 +125,14 @@ const illuminatedbollardsActivePopup = feature => {
     <p>${feature.properties.location_description}</p>
   </div>
 </div>
-<div class="smbc-map__item govuk-grid-column-full"> 
+<div class="smbc-map__item"> 
     <div class="smbc-map__item__header__block">
       <i class="fa fa-tag smbc-map__item__header__block__icon" aria-hidden="true"></i>
       <span class="smbc-map__item__header__block__title">Number on Bollard</span>
     </div>
     <div class="smbc-map__item__body">
       <p>${feature.properties.feature_id}</p>  
-        <a class="govuk-button govuk-!-margin-bottom-1" href="report-an-issue/fault-type?assetId=${feature.properties.central_asset_id}&siteCode=${feature.properties.site_code}">Report this bollard</a>
+        <a class="govuk-button govuk-!-margin-bottom-1 govuk-!-width-full" href="lit-bollard/fault-type?assetId=${feature.properties.central_asset_id}&siteCode=${feature.properties.site_code}">Report this bollard</a>
     </div>
   </div>`
 }
@@ -162,7 +162,7 @@ const illuminatedbollardsFaultPopup = feature => {
    <p>${feature.properties.location_description}</p>
  </div>
 </div>
-<div class="smbc-map__item govuk-grid-column-full">
+<div class="smbc-map__item">
    <div class="smbc-map__item__header__block">
      <i class="fa fa-tag smbc-map__item__header__block__icon" aria-hidden="true"></i>
      <span class="smbc-map__item__header__block__title">Sign ID</span>
@@ -174,7 +174,7 @@ const illuminatedbollardsFaultPopup = feature => {
        ${defaultMessage}
        </div>
      </div>
-       <a class="govuk-button govuk-!-margin-bottom-1" href="${varName}/track-a-report/details/${feature.properties.ext_system_ref}">View reported fault</a>
+       <a class="govuk-button govuk-!-margin-bottom-1 govuk-!-width-full" href="${varName}/track-a-report/details/${feature.properties.ext_system_ref}">View reported fault</a>
      ${showLastUpdated}
    </div>
    </div>`

--- a/Configuration/illuminated-bollards/index.js
+++ b/Configuration/illuminated-bollards/index.js
@@ -1,0 +1,32 @@
+import Leaflet from 'leaflet'
+import { illuminatedbollardsPopup } from '../illuminated-assets/Popups' //devsitesPopup, notdevsitesPopup}
+import { jobstatusStyle } from '../illuminated-assets/Styles'
+
+const Configuration = {
+    Map: {
+        embeddedInForm: true,
+        displayBoundary: true
+    },
+    Tiles: {
+        Token: '3G26OzBg7XRROryDwG1o1CZRmIx66ulo'
+        
+    },
+    DynamicData: 
+    [
+        {
+            key: 'Illuminated Bollards',
+            url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=highway_assets:illuminated_bollard_reporting&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+            layerOptions: {
+                maxZoom: 12,
+                onEachFeature: illuminatedbollardsPopup,
+                pointToLayer: (feature, latlng) => {
+                    return Leaflet.circleMarker (latlng, jobstatusStyle (feature))
+
+                }
+            },
+            displayOverlay: true,
+        },
+    ]
+}
+
+export default Configuration

--- a/Configuration/illuminated-signs/index.js
+++ b/Configuration/illuminated-signs/index.js
@@ -1,0 +1,32 @@
+import Leaflet from 'leaflet'
+import { illuminatedsignsPopup } from '../illuminated-assets/Popups' //devsitesPopup, notdevsitesPopup}
+import { jobstatusStyle } from '../illuminated-assets/Styles'
+
+const Configuration = {
+    Map: {
+        embeddedInForm: true,
+        displayBoundary: true
+    },
+    Tiles: {
+        Token: '3G26OzBg7XRROryDwG1o1CZRmIx66ulo'
+        
+    },
+    DynamicData: 
+    [
+        {
+            key: 'Illuminated Signs',
+            url:
+              'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=highway_assets:illuminated_sign_reporting&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+            layerOptions: {
+              onEachFeature: illuminatedsignsPopup,
+              maxZoom: 16,
+              pointToLayer: (feature, latlng) => {
+                return Leaflet.circleMarker (latlng, jobstatusStyle (feature))
+              }
+            },
+            displayOverlay: true,
+        }
+    ]
+}
+
+export default Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -3726,7 +3726,7 @@
     "babel-eslint": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
-      "integrity": "sha1-gaLGab4PIF4ZRi/tJILTPkaHqIo=",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3763,7 +3763,7 @@
     "babel-loader": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
-      "integrity": "sha1-4zvbbzYrA/S7FBoMIauHxQG3Dfs=",
+      "integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
@@ -3793,7 +3793,7 @@
     "babel-plugin-module-resolver": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-      "integrity": "sha1-3fpeMB47mqEthSqZefGLN4gf9ac=",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
       "dev": true,
       "requires": {
         "find-babel-config": "^1.1.0",
@@ -4504,7 +4504,7 @@
     "clean-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
-      "integrity": "sha1-qZ2Ow0wcYopFQVZ6p7RXRGRgxis=",
+      "integrity": "sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==",
       "dev": true,
       "requires": {
         "@types/webpack": "^4.4.31",
@@ -4646,7 +4646,7 @@
     "compression-webpack-plugin": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-3.1.0.tgz",
-      "integrity": "sha1-n1EBcqe1+uWq07ZwZS6L15l67so=",
+      "integrity": "sha512-iqTHj3rADN4yHwXMBrQa/xrncex/uEQy8QHlaTKxGchT/hC0SdlJlmL/5eRqffmWq2ep0/Romw6Ld39JjTR/ug==",
       "dev": true,
       "requires": {
         "cacache": "^13.0.1",
@@ -4660,7 +4660,7 @@
         "cacache": {
           "version": "13.0.1",
           "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
-          "integrity": "sha1-qAAMIWlwiQgvhSh6GuxuOCAkpxw=",
+          "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
           "dev": true,
           "requires": {
             "chownr": "^1.1.2",
@@ -4783,7 +4783,7 @@
         "serialize-javascript": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-          "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
+          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
           "dev": true
         },
         "ssri": {
@@ -5020,7 +5020,7 @@
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
-      "integrity": "sha1-Lkssfm4tJ/jI8o9hv/zS5ske9kU=",
+      "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
@@ -5070,7 +5070,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -5652,7 +5652,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -5684,7 +5684,7 @@
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
@@ -7982,7 +7982,7 @@
     "leaflet-gesture-handling": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/leaflet-gesture-handling/-/leaflet-gesture-handling-1.2.1.tgz",
-      "integrity": "sha1-2IyVJL6KlxoIi2oTa08pLTAW2ug="
+      "integrity": "sha512-MEod/3BmosTud0n/sw3iUecnOUDBz2U21gzwaOZS62voaNRkMj4Sm3XPjtnmivyMgYYF0tRHCMfVEYwcRsprUg=="
     },
     "leaflet.locatecontrol": {
       "version": "0.72.0",
@@ -8124,7 +8124,7 @@
     "mapbox-gl": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.1.tgz",
-      "integrity": "sha1-Mi7+datMdk/Ex3baFQaq1Y1aW50=",
+      "integrity": "sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -8154,7 +8154,7 @@
     "mapbox-gl-leaflet": {
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/mapbox-gl-leaflet/-/mapbox-gl-leaflet-0.0.15.tgz",
-      "integrity": "sha1-OvsH/Bv86Key9eHV7QWGyAl0P5Y="
+      "integrity": "sha512-dyuJLubdr/lBkf7ssqGrJCc4OCv6iZlYd/eqVzjKJOv0caPi69SLefm/Y3mfE5BMD6FiqtaZqIRDL0U5zWPlRg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -10732,7 +10732,7 @@
         "loader-utils": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha1-5MrOW4FtQloWa18JfhDNErNgZLA=",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -11248,7 +11248,7 @@
     "url-loader": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-3.0.0.tgz",
-      "integrity": "sha1-nx8Rs3Gs9uUe0VpQ22NeAu7Bg2g=",
+      "integrity": "sha512-a84JJbIA5xTFTWyjjcPdnsu+41o/SNE8SpXMdUvXs6Q+LuhCD9E2+0VCiuDWqgo3GGXVlFHzArDmBpj9PgWn4A==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.2.3",
@@ -11541,7 +11541,7 @@
         "eslint-scope": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-          "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
@@ -11604,7 +11604,7 @@
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,1 @@
-@import url("https://design-system.stockport.gov.uk/prod/1/smbc-frontend.min.css");
+@import url("https://design-system.stockport.gov.uk/int/1/smbc-frontend.min.css");

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -2,7 +2,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const path = require('path')
 const { DefinePlugin } = require('webpack')
 
-const solution = 'land-charges'
+const solution = 'illuminated-bollards'
 
 module.exports = (env, argv, t) => (
     {


### PR DESCRIPTION
…gns and bollards

### Description
Added config folders to generate separate maps for illuminated signs and illuminated bollards but using the illuminated-assets popups

Temporary change to styles to use int Design System to test a styling change (we should look at a better way of using int DS in develop and prod in master maybe)


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary