### PR TITLE
feat(ControlsExtension): add key handling

### DIFF
--- a/src/Extensions/Controls/index.js
+++ b/src/Extensions/Controls/index.js
@@ -29,12 +29,14 @@ Leaflet.Control.GroupedLayers = Leaflet.Control.extend({
       this._addLayer(baseLayers[layer], layer)
     }
 
-    for (layer in overlays) {
-      if (overlays[layer]._layers) {
-        this._addLayer(overlays[layer], layer, null, true)
-      } else {
-        for (subLayer in overlays[layer]) {
-          this._addLayer(overlays[layer][subLayer], subLayer, layer, true)
+    if (Object.keys(overlays).length > 0) {
+      for (layer in overlays) {
+        if (overlays[layer]._layers) {
+          this._addLayer(overlays[layer], layer, null, true)
+        } else {
+          for (subLayer in overlays[layer]) {
+            this._addLayer(overlays[layer][subLayer], subLayer, layer, true)
+          }
         }
       }
     }
@@ -241,9 +243,19 @@ Leaflet.Control.GroupedLayers = Leaflet.Control.extend({
     input.layerId = Leaflet.Util.stamp(obj.layer)
     input.groupId = obj.group.id
 
+    if (obj.layer.key && obj.layer.key.align === 'left') {
+      var key = Leaflet.DomUtil.create('span', `${baseClass}__key`, div)
+      key.innerHTML = obj.layer.key.graphic
+    }
+
     label = Leaflet.DomUtil.create('label', '', div)
     label.innerText = obj.name
     label.htmlFor = obj.name
+
+    if (obj.layer.key && obj.layer.key.align === 'below') {
+      var key = Leaflet.DomUtil.create('div', `${baseClass}__key--below`, div)
+      key.innerHTML = obj.layer.key.graphic
+    }
 
     this._layerControlInputs.push(input)
     Leaflet.DomEvent.on(input, 'click', this._onInputClick, this)
@@ -310,6 +322,7 @@ Leaflet.Control.GroupedLayers = Leaflet.Control.extend({
     }
 
     this._handlingClick = false
+    event.stopPropagation()
   },
 
   _onInputClick: function (event) {


### PR DESCRIPTION
### Description
-) Added length check to only run overlays if there are any.
-) Added Code to the Controls Extension to enable passing a key with the overlay.
  currently supports a default left aligned key, which will appear after the input and before the label
  **- or -** a more descriptive key describing the features within a layer which is aligned "below" the label for the layer
-) Added a "stop propagation" for handling of group input selections, so the event does not trigger the collapse of the group accordion.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary