### PR TITLE
Feature/key SVG

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ import 'leaflet/dist/leaflet.css'
 import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css'
 
 function App() {
-  const { Map, DynamicData, StaticData } = Config
+  const { Map, DynamicData, StaticData, LayerControlOptions } = Config
   const mapRef = useRef()
   const WMSLayerGroup = {}
   const DynamicLayerGroup = DynamicData == undefined ? [] : DynamicData.reduce(
@@ -54,7 +54,7 @@ function App() {
   const SetupControls = (clientWidth) => {
     setStaticLayers(StaticData, mapRef.current)
     setDynamicLayers(DynamicData, DynamicLayerGroup, WMSLayerGroup, mapRef.current)
-    setLayerControls(DynamicData, DynamicLayerGroup, WMSLayerGroup, mapRef.current)
+    setLayerControls(DynamicData, DynamicLayerGroup, WMSLayerGroup, mapRef.current, LayerControlOptions)
     setFullscreenControl(mapRef.current)
     setZoomControls(mapRef.current, clientWidth)
     setLocateControl(Map, mapRef.current, clientWidth)

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import Config from 'MapConfig'
 
-const { Map, Tiles, StaticData, DynamicData } = Config
+const { Map, Tiles, StaticData, DynamicData, LayerControlOptions } = Config
 
 const latitude: number = Map.Latitude ?? 53.3915
 const longitude: number = Map.Longitude ?? -2.125143
@@ -22,95 +22,88 @@ const hasMapClickFunction: boolean = Map.OnMapClick !== undefined
 const hasMapLoadFunction: boolean = Map.OnMapLoad !== undefined
 const hasAllowZoomToLocationOnLoad: boolean = Map.AllowZoomToLocationOnLoad == false ? false : true
 const enableGestureControl: boolean = Map.EnableGestureControl ?? false
+const defaultLayerControlOptions = {
+  collapsed: true,
+  position: 'topright',
+  autoZIndex: true,
+  groupCheckboxes: false,
+  keyGraphic: false
+}
 
 const processDataLayer = (layer) => {
-    const baseLayer = {
-        displayInOverlay: defaultdisplayInOverlay,
-        visibleByDefault: defaultVisibleByDefault,
-        layerOptions: {
-            maxZoom: defaultLayerMaxZoom,
-            minZoom: defaultLayerMinZoom
-        }
+  const baseLayer = {
+    displayInOverlay: defaultdisplayInOverlay,
+    visibleByDefault: defaultVisibleByDefault,
+    layerOptions: {
+      maxZoom: defaultLayerMaxZoom,
+      minZoom: defaultLayerMinZoom
     }
+  }
 
-    return { ...baseLayer, ...layer, layerOptions: { ...baseLayer.layerOptions, ...layer.layerOptions } }
+  return { ...baseLayer, ...layer, layerOptions: { ...baseLayer.layerOptions, ...layer.layerOptions } }
 }
 
 let staticData = []
 if (StaticData != undefined && StaticData.some) {
-    staticData = StaticData.map(processDataLayer)
+  staticData = StaticData.map(processDataLayer)
 }
 
 let dynamicData = []
 if (DynamicData != undefined && DynamicData.some) {
-    dynamicData = DynamicData.map(processDataLayer)
+  dynamicData = DynamicData.map(processDataLayer)
 }
 
 if (displayBoundary) {
-    staticData.push({
-        key: 'boundary',
-        url: 'https://maps.stockport.gov.uk/boundary.geojson',
-        layerOptions: {
-            interactive: false,
-            style: {
-                color: '#000',
-                weight: 4,
-                opacity: 1,
-                fillColor: '#000',
-                fillOpacity: 0
-            }
-        }
-    })
+  staticData.push({
+    key: 'boundary',
+    url: 'https://maps.stockport.gov.uk/boundary.geojson',
+    layerOptions: {
+      interactive: false,
+      style: {
+        color: '#000',
+        weight: 4,
+        opacity: 1,
+        fillColor: '#000',
+        fillOpacity: 0
+      }
+    }
+  })
 }
 
 if (displayOS1250) {
-    dynamicData.push({
-        key: 'os1250_line',
-        url: 'http://spatial.stockport.gov.uk/geoserver/wms?',
-        layerOptions: {
-            maxZoom: 20,
-            minZoom: os1250MinZoom,
-            layers: 'base_maps:os1250_line',
-            format: 'image/png',
-            transparent: true
-        },
-        displayInOverlay: false
-    })
-
-    dynamicData.push({
-        key: 'os1250_text',
-        url: 'http://spatial.stockport.gov.uk/geoserver/wms?',
-        layerOptions: {
-            maxZoom: 20,
-            minZoom: os1250MinZoom,
-            layers: 'base_maps:os1250_text',
-            format: 'image/png',
-            transparent: true
-        },
-        displayInOverlay: false
-    })
+  dynamicData.push({
+    key: 'os1250_line',
+    url: 'http://spatial.stockport.gov.uk/geoserver/wms?',
+    layerOptions: {
+      maxZoom: 20,
+      minZoom: os1250MinZoom,
+      layers: 'base_maps:os1250_line,base_maps:os1250_text',
+      format: 'image/png',
+      transparent: true
+    },
+    displayInOverlay: false
+  })
 }
 
 export default {
-    Map: {
-        StartingLatLng: [latitude, longitude],
-        Zoom: defaultStartZoom,
-        MinZoom: defaultMinimumZoom,
-        EnableLocateControl: enableLocateControl,
-        EmbeddedInForm: embeddedInForm,
-        Class: mapClass,
-        MapClickMinZoom: mapClickMinZoom,
-        DisplayBoundary: displayBoundary,
-        HasMapClickFunction: hasMapClickFunction,
-        HasMapLoadFunction: hasMapLoadFunction,
-        OnMapClick: Map.OnMapClick,
-        OnMapLoad: Map.OnMapLoad,
-        HasAllowZoomToLocation: hasAllowZoomToLocationOnLoad,
-        EnableGestureControl: enableGestureControl
-    },
-    Tiles: {
-        Token: Tiles.Token
-    },
-    DynamicData: dynamicData,
-    StaticData: staticData
+  Map: {
+    StartingLatLng: [latitude, longitude],
+    Zoom: defaultStartZoom,
+    MinZoom: defaultMinimumZoom,
+    EnableLocateControl: enableLocateControl,
+    EmbeddedInForm: embeddedInForm,
+    Class: mapClass,
+    MapClickMinZoom: mapClickMinZoom,
+    DisplayBoundary: displayBoundary,
+    HasMapClickFunction: hasMapClickFunction,
+    HasMapLoadFunction: hasMapLoadFunction,
+    OnMapClick: Map.OnMapClick,
+    OnMapLoad: Map.OnMapLoad,
+    HasAllowZoomToLocation: hasAllowZoomToLocationOnLoad,
+    EnableGestureControl: enableGestureControl
+  },
+  Tiles: { Token: Tiles.Token },
+  LayerControlOptions: Object.assign(defaultLayerControlOptions, LayerControlOptions),
+  DynamicData: dynamicData,
+  StaticData: staticData
 }

--- a/src/Controls/index.js
+++ b/src/Controls/index.js
@@ -102,7 +102,7 @@ const addKeyGraphicsToOverlays = (overlays, DynamicData) => {
       key = keyByType(options?.key?.type ?? 'default', options)
     }
 
-    if (key.graphic) {
+    if (key?.graphic) {
       layer.group ? overlays[layer.group][layer.key].key = key : overlays[layer.key].key = key
     }
   }

--- a/src/Controls/index.js
+++ b/src/Controls/index.js
@@ -114,6 +114,7 @@ const setLayerControls = (DynamicData, DynamicLayerGroup, WMSLayerGroup, map, op
   if (options.keyGraphic) {
     addKeyGraphicsToOverlays(overlays, DynamicData)
   }
+
   groupedLayers(controlLayers, overlays, options).addTo(map)
 }
 

--- a/src/Controls/index.js
+++ b/src/Controls/index.js
@@ -3,7 +3,7 @@ import groupedLayers from '../Extensions/Controls'
 import searchControl from '../Extensions/Search'
 import Leaflet from 'leaflet'
 import { MAX_WIDTH_MOBILE } from '../Constants'
-import { fetchData } from '../Helpers'
+import { fetchData, keyByType } from '../Helpers'
 
 const AddLayerControlsLayers = () => (
   {
@@ -89,10 +89,32 @@ const setFullscreenControl = (map) => (
     .addTo(map)
 )
 
-const setLayerControls = (DynamicData, DynamicLayerGroup, WMSLayerGroup, map) => {
+const addKeyGraphicsToOverlays = (overlays, DynamicData) => {
+  var layers = DynamicData.filter(layer => layer.displayInOverlay)
+  for (const layer of layers) {
+    var options = layer.layerOptions
+    if (options.key !== undefined && !options.key) continue
+    var key
+
+    if (layer.url.endsWith('wms?') && !options.key) {
+      // TO DO: To be implemented - pass url to <img src="https://geoserver.WMS.GetLegendGraphic()" />
+    } else {
+      key = keyByType(options?.key?.type ?? 'default', options)
+    }
+
+    if (key.graphic) {
+      layer.group ? overlays[layer.group][layer.key].key = key : overlays[layer.key].key = key
+    }
+  }
+}
+
+const setLayerControls = (DynamicData, DynamicLayerGroup, WMSLayerGroup, map, options) => {
   const controlLayers = AddLayerControlsLayers()
   const overlays = AddLayerControlsOverlays(DynamicData, DynamicLayerGroup, WMSLayerGroup, map)
-  groupedLayers(controlLayers, overlays).addTo(map)
+  if (options.keyGraphic) {
+    addKeyGraphicsToOverlays(overlays, DynamicData)
+  }
+  groupedLayers(controlLayers, overlays, options).addTo(map)
 }
 
 const setStaticLayers = async (StaticData, Map) => {

--- a/src/Extensions/Controls/index.js
+++ b/src/Extensions/Controls/index.js
@@ -244,8 +244,8 @@ Leaflet.Control.GroupedLayers = Leaflet.Control.extend({
     input.groupId = obj.group.id
 
     if (obj.layer.key && obj.layer.key.align === 'left') {
-      var key = Leaflet.DomUtil.create('span', `${baseClass}__key`, div)
-      key.innerHTML = obj.layer.key.graphic
+      Leaflet.DomUtil.create('span', `${baseClass}__key`, div)
+        .innerHTML = obj.layer.key.graphic
     }
 
     label = Leaflet.DomUtil.create('label', '', div)
@@ -253,8 +253,8 @@ Leaflet.Control.GroupedLayers = Leaflet.Control.extend({
     label.htmlFor = obj.name
 
     if (obj.layer.key && obj.layer.key.align === 'below') {
-      var key = Leaflet.DomUtil.create('div', `${baseClass}__key--below`, div)
-      key.innerHTML = obj.layer.key.graphic
+      Leaflet.DomUtil.create('div', `${baseClass}__key--below`, div)
+        .innerHTML = obj.layer.key.graphic
     }
 
     this._layerControlInputs.push(input)

--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -43,8 +43,108 @@ const getQueryStringParams = query => {
         : {}
 }
 
+const cssToSVG = style => {
+  // https://www.w3.org/TR/SVG/styling.html
+  var inlineStyle = ''
+
+  inlineStyle += style.fillColor ? `fill:${style.fillColor};`: ''
+  inlineStyle += style.fillOpacity >= 0 ? `fill-opacity:${style.fillOpacity};`: ''
+
+  inlineStyle += style.color ? `stroke:${style.color};`: ''
+  inlineStyle += style.weight ? `stroke-width:${style.weight};`: ''
+  inlineStyle += style.opacity >= 0 ? `stroke-opacity:${style.opacity};`: ''
+
+  inlineStyle += style.dashArray ? `stroke-dasharray:${style.dashArray};`: ''
+  inlineStyle += style.dashOffset ? `stroke-dashoffset:${style.dashOffset};`: ''
+
+  return inlineStyle
+}
+
+const svgSquare = style => {
+  return svgElement(`<rect x="2" y="2" width="14" height="14" style="${typeof style === 'object' ? cssToSVG(style) : style}" />`)
+}
+
+const svgCircle = style => {
+  return svgElement(`<circle cx="9" cy="9" r="6" style="${typeof style === 'object' ? cssToSVG(style) : style}" />`)
+}
+
+const svgPolyline = options => {
+  var inlineStyle
+
+  if (typeof options.style === 'object') {
+    options.style.fillColor = 'none'
+    inlineStyle = cssToSVG(options.style)
+  } else {
+    inlineStyle = options.style
+  }
+
+  return svgElement(`<polyline points="${options.points ?? '0 18,18 0'}" style="${inlineStyle}" />`)
+}
+
+const svgArray = options => {
+  var array = ''
+  for (var graphic of options.key.graphic) {
+    var type = graphic.type ?? ( options.pointToLayer ? 'circle' : 'square' )
+    var svgOptions = type === 'pline' ? { points: graphic?.points, style: graphic.style } : graphic.style
+    array += `<div>${svgByType(type, svgOptions)}<span>${graphic.text}</span></div>`
+  }
+  return array
+}
+
+const svgByType = (type, options) => {
+  switch (type) {
+    case 'svg':
+      return svgElement(options)
+
+    case 'pline':
+      return svgPolyline(options)
+
+    case 'circle':
+      return svgCircle(options)
+
+    case 'square':
+      return svgSquare(options)
+  }
+}
+
+const keyByType = (type, options) => {
+  switch (type) {
+    case 'svg':
+      return {
+        align: options.key?.align ?? 'left',
+        graphic: svgByType(type, options.key.graphic)
+      }
+
+    case 'array':
+    case 'list':
+      return {
+        align: options.key?.align ?? 'below',
+        graphic: svgArray(options)
+      }
+
+    case 'pline':
+    case 'polyline':
+      return {
+        align: options.key?.align ?? 'left',
+        graphic: svgByType('pline', { points: options.key?.points, style: options.style })
+      }
+
+    default:
+      var circle = options.pointToLayer
+      if (circle && !options.style) return // these need to be a custom built key
+      if (typeof options.style == 'function') return // these need to be a custom built key
+      return {
+        align: options.key?.align ?? 'left',
+        graphic: svgByType(circle ? 'circle' : 'square', options.style)
+      }
+  }
+}
+
+const svgElement = svg => `<svg width="18" height="18" class="smbc-control-layers__svg">${svg}</svg>`
+
 export {
-    fetchData,
-    fetchAddressData,
-    getQueryStringParams
+  fetchData,
+  fetchAddressData,
+  getQueryStringParams,
+  keyByType
 }


### PR DESCRIPTION
### Description
-) Extension/Controls : removed unnecessary, and incorrectly declared, "key" variable.
-) Configuration : merge ( using JS Object.assign() ) Layer Control Options from individual Map Config if any, or pass default.
-) App : Pass the Layer Control Options object from Configuration to the Controls > Set Layer Controls
-) Controls : if Map Config has LayerControlOptions: { KeyGraphic: true }, this will then call addKeyGraphicsToOverlays function
  This currently will if/else on the layer url ( due to the next feature of using WMS for overlays, and this has it's own graphic )
  So, this feature is currently for the "custom" key graphic of using SVGs to represent layers
-) Helpers : Numerous SVG functions, currently enabling custom svg elements to be passed from a Map Config, or a simple selection of Circle, Square, or Polyline. Also handles an array of "keys" for when a more in-depth key is required.

**To test**
-) Pull the branch
-) change launch mapping solution to contact-centre ( or any that has a mix of layers using styles based on a function )
-) Add below config above DynamicData
  LayerControlOptions: {
    keyGraphic: true
  },
  DynamicData: [

-) see all layers that have style set as an object have either a circle or square SVG, based on their CSS style.

-) The styles "smbc-control-layers__svg", "smbc-control-layers__key", and "smbc-control-layers__key--below", will be added through the Design System.


**Extra testing of the features capabilities**
-) **Public Rights of way** looks strange as a square;
  -) to view key as a line;  add the "key" object in the layerOptions, and set the "type" as "pline" or "polyline"
        maxZoom: 16,
        style: prowStyle,
         **key: {
          type: 'pline'
        }**
  -) to disable the key on this ( or any ) layer, set the "key: false" in the layerOptions
        maxZoom: 16,
        style: prowStyle,
        key: false

-) **Gritting Boxes** does not have a key, as it's style is based on a function. So, let's create a custom key based on the features we  know exist in/on that layer.
  -) in the layerOptions, specify a key object. have the first property of the "key" to be a type: 'array' or a 'list'. Then create a new property called "graphic" with an array of values, **text: 'title to use'**, **style: 'inline svg style, or css object'**. see below;
        key: {
          type: 'array',
          graphic: [
            { text: 'Highway', style: 'fill:#ff7f00;stroke:black;stroke-width:1;' },
            { text: 'Park', style: 'fill:#3f007d;stroke:black;stroke-width:1;' }
          ]
        }

-) **Gritting Routes** also has a function style. If you add the below snippet to the layerOptions it creates a key using polylines instead of the default squares
        maxZoom: 16,
        style: grittingroutesStyle,
        key: {
          type: 'array',
          graphic: [
            { type: 'pline', text: 'Trailer', style: 'fill:none;stroke:#ffff99;stroke-width:4;' },
            { type: 'pline', text: 'Supervisor', style: 'fill:none;stroke:#6a3d9a;stroke-width:4;' },
            { type: 'pline', text: 'Primary', style: 'fill:none;stroke:#e31a1c;stroke-width:4;' },
            { type: 'pline', text: 'Other', style: 'fill:none;stroke:#33a02c;stroke-width:4;' }
          ]
        }

-) **Council Owned land**. Add below snippet to create a default square graphic for each feature in the layer.
        maxZoom: 16,
        style: LandOwnershipstyle,
        key: {
          type: 'array',
          graphic: [
            { text: 'Corporate', style: 'fill:#ffff00;fill-opacity:0.5;' },
            { text: 'Education', style: 'fill:#ffaf5f;fill-opacity:0.5;' },
            { text: 'Green Space', style: 'fill:#55ff55;fill-opacity:0.5;' },
            { text: 'Highways', style: 'fill:#3255ff;fill-opacity:0.5;' },
            { text: 'Social Services', style: 'fill:#c88cff;fill-opacity:0.5;' },
            { text: 'Stockport Homes', style: 'fill:#d70000;fill-opacity:0.5;' },
            { text: 'Strategic Housing', style: 'fill:#15ebf6;fill-opacity:0.5;' }
          ]
        }

...

This has been approved for use by Chris and Jaime of how the config is specified...
The "simple" version of this cannot pick up on all the features within a layer, so they are happy that when they opt in to using "layer controls key" features, a map must have something specified when the layer's style is based on a function.




### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary