### PR TITLE
Feature/wms

### DIFF
--- a/Configuration/con29-wms/Popups/index.js
+++ b/Configuration/con29-wms/Popups/index.js
@@ -1,0 +1,949 @@
+const buildingregsapprovalPopup = (properties) => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.1 - Building Regulations Approval</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Application No.: ${properties.refval}</p>
+    <p>Address: ${properties.address}</p>
+    <p>App Type: ${properties.app_type}</p>
+    <p>Description: ${properties.dscrpn}</p>
+    <p>Decision: ${properties.decision}</p>
+    <p>Decision Date: ${properties.decidd}</p>
+  </div>
+</div>`
+}
+
+const buildingcertPopup = (properties) => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-certificate smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.1 - Building Certificates</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Application No.: ${properties.refval}</p>
+    <p>Address: ${properties.address}</p>
+    <p>Application Type: ${properties.app_type}</p>
+    <p>Description: ${properties.dscrpn}</p>
+    <p>Completion Cert Issued: ${properties.compissd}</p>
+  </div>
+</div>`
+}
+
+const conservationareaPopup = (properties) => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-certificate smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Conservation Areas</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>${properties.cons_area}</p>
+  </div>
+</div>`
+}
+
+const floodzonesPopup = (properties) => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-tint smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Flood Zones</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Risk Level: ${properties.risk_level}</p>
+    <p>Type: ${properties.type}</p>
+    <p>Source: ${properties.source}</p>
+  </div>
+</div>`
+}
+
+const greenbeltPopup = () => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fafa-pagelines smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Green Belt</span>
+  </div>
+</div>`
+}
+
+const greenbeltmedsPopup = (properties) => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-building-o smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Green Belt MEDS</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${properties.name}</p>
+    <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`
+}
+
+const generalPopup = (properties) => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - General</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${properties.tquniqueid}</p>
+    <p>Policy: ${properties.policy_1}</p>
+  </div>
+</div>`
+}
+
+const greenchainPopup = (properties) => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-leaf smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Green Chain</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>ID: ${properties.id}</p>
+  <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`
+}
+
+const gravel_aosPopup = (properties) => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-search smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Gravel</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>ID: ${properties.id}</p>
+    <p>Name: ${properties.name}</p>
+    <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`
+}
+
+const housingsitesPopup = (properties) => {
+  return `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-home smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Housing Sites</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>ID: ${properties.id}</p>
+  <p>Name: ${properties.name}</p>
+  <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`
+}
+
+ const landscapecharacterareaPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Landscape Character Area</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${properties.name}</p>
+    <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`
+
+  layer.bindPopup(content)
+ }
+
+ const localnaturereservePopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-tree smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Local Nature Reserve</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Name: ${properties.reserve_na}</p>
+  </div>
+</div>`
+
+  layer.bindPopup(content)
+ }
+
+const localopenspacePopup = (feature, layer) => {
+  
+const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-leaf smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Local Open Space</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>ID: ${properties.id}</p>
+    <p>Name: ${properties.name}</p>
+    <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`
+
+layer.bindPopup(content)
+}
+
+const localwildlifesitesPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-pagelines smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Local Wildlife Sites</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>ID: ${properties.id}</p>
+    <p">Policy: ${properties.policy}</p>
+  </div>
+</div>` 
+
+  layer.bindPopup(content)
+  }
+
+const metrolinkcorridorPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-subway smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Metrolink Corridor</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Chapter: ${properties.chapter}</p>
+    <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`    
+
+  layer.bindPopup(content)
+  }
+
+const m60gatewaysitesPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - M60 Gateway Sites</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Chapter: ${properties.chapter}</p>
+  <p>Name: ${properties.name}</p>
+  <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`    
+     
+  layer.bindPopup(content)
+  }
+
+const parkgardenofhistoricinterestPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-tree smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Park or Garden of Historic Interest</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Site: ${properties.site}</p>
+  </div>
+</div>`
+
+  layer.bindPopup(content)
+  }
+
+const pgasPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-file-text smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Policy Guidance Areas</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>ID: ${properties.id}</p>
+  <p>Name: ${properties.name}</p>
+  <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`
+
+  layer.bindPopup(content)
+  }
+
+const predominantlyresidentialPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-home smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Predominantly Residential Areas</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>ID: ${properties.id}</p>
+  <p>Name: ${properties.name}</p>
+  <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`
+
+  layer.bindPopup(content)
+  }
+
+const reliefroadcorridorPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Relief Road Corridor</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>ID: ${properties.id}</p>
+  <p>Name: ${properties.name}</p>
+  <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`         
+
+  layer.bindPopup(content)
+  }
+
+const sandaosPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-search smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Sand - Area of Search</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>ID: ${properties.id}</p>
+  <p>Name: ${properties.name}</p>
+  <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`    
+
+  layer.bindPopup(content)
+  }
+
+const sandgritaosPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-search smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Sandstone/Gritstone - Area of Search</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>ID: ${properties.id}</p>
+  <p>Name: ${properties.name}</p>
+  <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`    
+
+  layer.bindPopup(content)
+  }
+
+const shopfrontagesPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-shopping-basket smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Shop Frontages</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>ID: ${properties.id}</p>
+    <p>Name: ${properties.policyname}</p>
+    <p>Policy: ${properties.policysitename}</p>
+  </div>
+</div>`    
+                 
+  layer.bindPopup(content)
+  }
+
+const shoppingtcPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-shopping-cart smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Shopping TC</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Area: ${properties.shoppingareas}</p>
+    <p>Policy: ${properties.policy_1}</p>
+  </div>
+</div>`   
+                   
+  layer.bindPopup(content)
+  }
+
+const shoppingareasPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-shopping-cart smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Shopping Areas</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Name: ${properties.policysitename}</p>
+  <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`   
+                     
+  layer.bindPopup(content)
+  }
+
+const sbiPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-leaf smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Sites of Biological Importance</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Site Name: ${properties.site_name}</p>
+  <p>Reference Number: ${properties.reference_number}</p>
+  </div>
+</div>`   
+                       
+  layer.bindPopup(content)
+  }
+
+const sssiPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-flask smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Sites of Special Scientific Interest</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Site Name: ${properties.sssi_name}</p>
+    <p>Site Name: ${properties.sssi_area}</p>
+    <p>Designation Status: ${properties.designation_status}</p>
+  </div>
+</div>`   
+                         
+  layer.bindPopup(content)
+  }
+
+const strategicopenspacePopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-tree smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Strategic Open Space</span>
+  </div>
+  <div class="smbc-map__item__body">
+   <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`   
+                           
+  layer.bindPopup(content)
+  }
+
+const strategicrecreationroutesPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-bicycle smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Strategic Recreation Routes</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>ID: ${properties.id}</p>
+    <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`   
+                             
+  layer.bindPopup(content)
+  }
+
+const towncentreareasPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-building smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q1.2 - Town Centre Areas</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>ID: ${properties.id}</p>
+    <p>Name: ${properties.name}</p>
+    <p>Policy: ${properties.policy}</p>
+  </div>
+</div>`   
+                               
+  layer.bindPopup(content)
+  }
+
+const adopted_highwaysPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q2.1 - Adopted Highways</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>USRN: ${properties.usrn}</p>
+    <p>Street: ${properties.street}</p>
+  </div>
+</div>`
+                                 
+  layer.bindPopup(content)
+  }
+
+const section38Popup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Section 38 Agreements</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Description: ${properties.description}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }  
+
+const privatestreetworksPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q2.1 - Private Streetworks</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>USRN: ${properties.usrn}</p>
+    <p>Street: ${feature.thorofare}</p>
+  </div>
+</div>`
+                                  
+  layer.bindPopup(content)
+  }
+  
+const trunk200Popup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.4 - Trunk Road 200m Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Name: ${properties.scheme_type}</p>
+  <p>Scheme Description: ${properties.short_description}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+  
+const roadalterationsPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.4 - Road Alterations</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Type: ${properties.scheme_type}</p>
+  <p>Details: ${properties.short_description}</p>
+  <p>Date for Completion: ${properties.date_for_completion}</p>
+  <p>Reference: ${properties.unique_reference}</p>
+  </div>
+</div>`
+                                      
+  layer.bindPopup(content)
+  }
+
+  const threefourPopup = (feature, layer) => {
+  
+    const content = `<div class="smbc-map__item">
+    <div class="smbc-map__item__header__block">
+      <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+      <span class="smbc-map__item__header__block__title">Q3.4 - Road Alterations</span>
+    </div>
+    <div class="smbc-map__item__body">
+    <p>Description: ${properties.description}</p>
+    </div>
+  </div>`
+                                        
+    layer.bindPopup(content)
+    }
+
+const newroadPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.4 - New Road Construction</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Type: ${properties.scheme_type}</p>
+  <p>Details: ${properties.short_description}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+
+const newroadconsultPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.4 - Proposed New Road Consultation</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Scheme Type: ${properties.scheme_type}</p>
+    <p>Short Description: ${properties.short_description}</p>
+  </div>
+</div>`
+                                          
+  layer.bindPopup(content)
+  }
+
+const newrailwayPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-subway smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.5 - Proposed Rail Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Scheme Type: ${properties.scheme}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+
+const waitingPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.6 - Waiting or Loading Restrictions 200m Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Type: ${properties.restriction_type}</p>
+  <p>Short Description: ${properties.description}</p>
+  </div>
+</div>`
+                                                
+  layer.bindPopup(content)
+  }
+
+const onewayPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.6 - One Way Traffic 200m Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Type: ${properties.restriction_type}</p>
+  <p>Short Description: ${properties.description}</p>
+  </div>
+</div>`
+                                                  
+  layer.bindPopup(content)
+  }
+
+const prohibitionofdrivingPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.6 - Prohibition of Driving 200m Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Scheme Type: ${properties.restriction_type}</p>
+    <p>Short Description: ${properties.description}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+
+const pedestrianisationPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.6 - Pedestrianisation 200m Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Type: ${properties.restriction_type}</p>
+  <p>Short Description: ${properties.description}</p>
+  </div>
+</div>`
+                                                      
+  layer.bindPopup(content)
+  }
+
+const widthweightPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.6 - Width and Weight Restrictions 200m Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Type: ${properties.restriction_type}</p>
+  <p>Short Description: ${properties.description}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+
+const trafficcalmingPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.6 - Traffic Calming Measures 200m Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Type: ${properties.restriction_type}</p>
+  <p>Short Description: ${properties.description}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+
+const residentsparkingPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-car smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.6 - Resident Parking Controls Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Type: ${properties.restriction_type}</p>
+  <p>Short Description: ${properties.description}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+
+const minorroadalterationsPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.6 - Minor Road Alterations Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Short Description: ${properties.description}</p>
+  </div>
+</div>`
+                                                              
+  layer.bindPopup(content)
+  }
+
+const cycletrackPopup = (feature, layer) => {
+  
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-road smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.6 - Cycle Track Buffer</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme Type: ${properties.restriction_type}</p>
+  <p>Short Description: ${properties.description}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+
+const stopnoticePopup = (feature, layer) => {
+ 
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.9 - Stop Notice</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Case Ref: ${properties.casefulref}</p>
+  </div>
+</div>`
+                                                                  
+  layer.bindPopup(content)
+  }
+
+const listbuildingenfPopup = (feature, layer) => {
+ 
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.9 - Listed Building Enforcement Notice</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Case Ref: ${properties.casefulref}</p>
+  </div>
+</div>`
+                                                                    
+  layer.bindPopup(content)
+  }
+
+const breachconditionPopup = (feature, layer) => {
+
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.9 - Breach of Condition Notice</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Case Ref: ${properties.casefulref}</p>
+  </div>
+</div>`
+                                                                      
+  layer.bindPopup(content)
+  }
+
+const planningcontraPopup = (feature, layer) => {
+
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.9 - Planning Contravention Notice</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Case Ref: ${properties.casefulref}</p>
+  </div>
+</div>`
+                                                                        
+  layer.bindPopup(content)
+  }
+
+const othernoticePopup = (feature, layer) => {
+
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.9 - Other Notice</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Case Ref: ${properties.casefulref}</p>
+  </div>
+</div>`
+                                                                          
+  layer.bindPopup(content)
+  }
+
+const tpoPopup = (feature, layer) => {
+
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.9 - Tree Preservation Orders</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Status: ${properties.status}</p>
+  <p>Address: ${properties.tpo_name}</p>
+  <p>TPO Ref: ${properties.tpo_number} ${properties.tree_number}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+
+const cpoPopup = (feature, layer) => {
+
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.12 - Compulsory Purchase Orders</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Scheme: ${properties.scheme_name}</p>
+  <p>Description: ${properties.description}</p>
+  </div>
+</div>`
+  
+  layer.bindPopup(content)
+  }
+
+const radonPopup = (feature, layer) => {
+
+  const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.14 Radon Gas</span>
+  </div>
+  <div class="smbc-map__item__body">
+  <p>Class: ${properties.class}</p>
+  </div>
+</div>`
+                                                                                
+  layer.bindPopup(content)
+  }
+
+  const enforcementnoticePopup = (feature, layer) => {
+
+    const content = `<div class="smbc-map__item">
+  <div class="smbc-map__item__header__block">
+    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
+    <span class="smbc-map__item__header__block__title">Q3.9 Enforcement Notice</span>
+  </div>
+  <div class="smbc-map__item__body">
+    <p>Ref: ${properties.refval}</p>
+    <p>Address: ${properties.address}</p>
+    <p>Description: ${properties.nature}</p>
+    <p>Action: ${properties.action}</p>    
+  </div>
+</div>`
+    
+    layer.bindPopup(content)
+    }
+
+export {
+  buildingregsapprovalPopup, 
+  buildingcertPopup,
+  conservationareaPopup,
+  floodzonesPopup,
+  greenbeltPopup,
+  greenbeltmedsPopup,
+  generalPopup,
+  greenchainPopup,
+  gravel_aosPopup,
+  housingsitesPopup,
+  landscapecharacterareaPopup,
+  localnaturereservePopup,
+  localopenspacePopup,
+  localwildlifesitesPopup,
+  metrolinkcorridorPopup,
+  m60gatewaysitesPopup,
+  parkgardenofhistoricinterestPopup,
+  pgasPopup,
+  predominantlyresidentialPopup,
+  reliefroadcorridorPopup,
+  sandaosPopup,
+  sandgritaosPopup,
+  shopfrontagesPopup,
+  shoppingtcPopup,
+  shoppingareasPopup,
+  sbiPopup,
+  sssiPopup,
+  strategicopenspacePopup,
+  strategicrecreationroutesPopup,
+  towncentreareasPopup,
+  adopted_highwaysPopup, 
+  section38Popup, 
+  privatestreetworksPopup,
+  trunk200Popup,
+  roadalterationsPopup,
+  newroadPopup,
+  newroadconsultPopup,
+  newrailwayPopup,
+  waitingPopup,
+  onewayPopup,
+  prohibitionofdrivingPopup,
+  pedestrianisationPopup,
+  widthweightPopup,
+  trafficcalmingPopup,
+  residentsparkingPopup,
+  minorroadalterationsPopup,
+  //pedestriancrossingPopup,
+  cycletrackPopup,
+  stopnoticePopup,
+  listbuildingenfPopup,
+  breachconditionPopup,
+  planningcontraPopup,
+  othernoticePopup,
+  tpoPopup,
+  radonPopup,
+  cpoPopup,
+  enforcementnoticePopup,
+  threefourPopup
+}

--- a/Configuration/con29-wms/index.js
+++ b/Configuration/con29-wms/index.js
@@ -1,35 +1,27 @@
 import { 
   buildingregsapprovalPopup,
   buildingcertPopup,
-  conservationareaPopup
+  conservationareaPopup,
+  floodzonesPopup
 } from './Popups'
 
-// Leaflet default '0' => World View
-const minZoom = 12 // (Zoom out to - Street Level)
-
-// Leaflet default '18' => Street Level
-const maxZoom = 20 // (Zoom down to - House View)
-
-// IF all layers have the same constraints
-// Specify "LayerVisibleFrom / ...To" within "Map"
-// OR specify "minZoom / maxZoom" on each layer
 const Configuration = {
   Map: {
     StartingZoom: 19,
-    LayersVisibleFrom: minZoom,
-    LayersVisibleTo: maxZoom
+    LayersVisibleFrom: 18, // ("minimum zoom" - Zoom out to - Street Level)
+    LayersVisibleTo: 20 // ("maximum zoon" - Zoom down to - House View)
   },
   Tiles: { Token: '3G26OzBg7XRROryDwG1o1CZRmIx66ulo' },
+  LayerControlOptions: { keyGraphic: true, groupCheckboxes: true },
   DynamicData: 
   [
     {
       key: 'Planning Applications',
+      group: 'Q1.1',
       url: 'wms',
       layerOptions: {
-        layers: 'con29:planning_applications_con29', // planning:green_belt_os
-        // minZoom: 12,
+        layers: 'con29:planning_applications_con29',
         popup: {
-          // title: 'Custom Title - Planning Applications', // or taken from "Group" + "Key" -or- just "Key" if no group specified
           icon: 'fa fa-building',
           body: {
             'Planning Application No.': 'refval',
@@ -44,6 +36,7 @@ const Configuration = {
     },
     {
       key: 'Building Regulations Approval',
+      group: 'Q1.1',
       url: 'wms',
       layerOptions: {
         layers: 'con29:1_1j',
@@ -52,25 +45,36 @@ const Configuration = {
     },
     {
       key: 'Building Certificate',
+      group: 'Q1.1',
       url: 'wms',
       layerOptions: {
         layers: 'con29:1_1k',
-        popup: buildingcertPopup
+        popup: buildingcertPopup,
+        key: {
+          align: 'below'
+        }
       }
     },
     {
       key: 'Airport Public Safety Zone',
+      group: 'Q1.2',
       url: 'wms',
       layerOptions: {
         layers: 'planning:airport_public_safety_zone',
+        key: {
+          align: 'below'
+        },
         popup: {
           icon: 'fa fa-plane',
-          body: { 'Policy': 'policy' }
+          body: {
+            'Policy': 'policy'
+          }
         }
       }
     },
     {
       key: 'Ancient Monuments',
+      group: 'Q1.2',
       url: 'wms',
       layerOptions: {
         layers: 'heritage:ancient_monument',
@@ -85,17 +89,21 @@ const Configuration = {
     },
     {
       key: 'Conservation Areas',
+      group: 'Q1.2',
       url: 'wms',
       layerOptions: {
         layers: 'heritage:conservation_area',
+        key: { align: 'below' },
         popup: conservationareaPopup
       }
     },
     {
       key: 'Employment Areas',
+      group: 'Q1.2',
       url: 'wms',
       layerOptions: {
         layers: 'planning_udp:employment_areas',
+        key: { align: 'below' },
         popup: {
           icon: 'fa fa-briefcase',
           body: {
@@ -108,9 +116,11 @@ const Configuration = {
     },
     {
       key: 'Employment Proposed',
+      group: 'Q1.2',
       url: 'wms',
       layerOptions: {
         layers: 'planning_udp:employment_proposed',
+        key: { align: 'below' },
         popup: {
           icon: 'fa fa-briefcase',
           body: {
@@ -122,6 +132,7 @@ const Configuration = {
     },
     {
       key: 'Definitive Rights of Way',
+      group: 'Q1.2',
       url: 'wms',
       layerOptions: {
         layers: 'highways:public_rights_of_way',
@@ -133,674 +144,18 @@ const Configuration = {
           }
         }
       }
+    },
+    {
+        key: 'Flood Zones',
+        group: 'Q1.2',
+        url: 'wms',
+        layerOptions: {
+          layers: 'flooding:flood_zones',
+          key: { align: 'below' },
+          popup: floodzonesPopup,
+        }
     }
-    // {
-    //     key: 'Q1.2 - Flood Zones',
-    //     url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=flooding:flood_zones&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-    //     layerOptions: {
-    //         maxZoom: 17,
-    //         style: floodzonesStyle,
-    //         onEachFeature: floodzonesPopup
-    //     }
-    // },
-      // {
-      //   key: 'Flood Zones',
-      //   group: 'Q1.2',
-      //   url: 'wms',
-      //   popup: floodzonesPopup,
-      //   layerOptions: {
-      //     layers: 'flooding:flood_zones',
-      //     format: 'image/png',
-      //     minZoom: 18, // default '0' => World View
-      //     maxZoom: 20, // Default '18', Street Level
-      //     keepBuffer: 10,
-      //     tileSize: 256,
-      //     transparent: true
-      //   },
-      //   displayInOverlay: true
-      // },
-      // //   {
-      // //       key: 'Q1.2 - Green Belt',
-      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning:green_belt_os&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      // //       layerOptions: {
-      // //           maxZoom: 17,
-      // //           style: greenbeltStyle,
-      // //           onEachFeature: greenbeltPopup
-      // //       }
-      // //   },
-      // {
-      //   key: 'Green Belt',
-      //   group: 'Q1.2',
-      //   url: 'wms',
-      //   popup: greenbeltPopup,
-      //   layerOptions: {
-      //     layers: 'planning:green_belt_os',
-      //     format: 'image/png',
-      //     minZoom: 18, // default '0' => World View
-      //     maxZoom: 20, // Default '18', Street Level
-      //     keepBuffer: 10,
-      //     tileSize: 256,
-      //     transparent: true
-      //   },
-      //   displayInOverlay: true
-      // },
-      // //   {
-      // //       key: 'Q1.2 - Major Existing Development Sites in the Green Belt (MEDS)',
-      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:greenbelt_meds&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      // //       layerOptions: {
-      // //           maxZoom: 17,
-      // //           style: greenbeltmedsStyle,
-      // //           onEachFeature: greenbeltmedsPopup
-      // //       }
-      // //   },
-      // {
-      //   key: 'Major Existing Development Sites in the Green Belt (MEDS)',
-      //   group: 'Q1.2',
-      //   url: 'wms',
-      //   popup: greenbeltmedsPopup,
-      //   layerOptions: {
-      //     layers: 'planning_udp:greenbelt_meds',
-      //     format: 'image/png',
-      //     minZoom: 18, // default '0' => World View
-      //     maxZoom: 20, // Default '18', Street Level
-      //     keepBuffer: 10,
-      //     tileSize: 256,
-      //     transparent: true
-      //   },
-      //   displayInOverlay: true
-      // },
-      // //   {
-      // //       key: 'Q1.2 - General',
-      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:general&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      // //       layerOptions: {
-      // //           maxZoom: 17,
-      // //           style: generalStyle,
-      // //           onEachFeature: generalPopup
-      // //       }
-      // //   },
-      // {
-      //   key: 'General',
-      //   group: 'Q1.2',
-      //   url: 'wms',
-      //   popup: generalPopup,
-      //   layerOptions: {
-      //     layers: 'planning_udp:general',
-      //     format: 'image/png',
-      //     minZoom: 18, // default '0' => World View
-      //     maxZoom: 20, // Default '18', Street Level
-      //     keepBuffer: 10,
-      //     tileSize: 256,
-      //     transparent: true
-      //   },
-      //   displayInOverlay: true
-      // },
-      // //   {
-      // //       key: 'Q1.2 - Green Chain',
-      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:green_chain&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      // //       layerOptions: {
-      // //           maxZoom: 17,
-      // //           style: greenchainStyle,
-      // //           onEachFeature: greenchainPopup
-      // //       }
-      // //   },
-      // {
-      //   key: 'Green Chain',
-      //   group: 'Q1.2',
-      //   url: 'wms',
-      //   popup: greenchainPopup,
-      //   layerOptions: {
-      //     layers: 'planning_udp:green_chain',
-      //     format: 'image/png',
-      //     minZoom: 18, // default '0' => World View
-      //     maxZoom: 20, // Default '18', Street Level
-      //     keepBuffer: 10,
-      //     tileSize: 256,
-      //     transparent: true
-      //   },
-      //   displayInOverlay: true
-      // },
-      // //   {
-      // //       key: 'Q1.2 - Gravel',
-      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:gravel_aos&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      // //       layerOptions: {
-      // //           maxZoom: 17,
-      // //           style: gravel_aosStyle,
-      // //           onEachFeature: gravel_aosPopup
-      // //       }
-      // //   },
-      // {
-      //   key: 'Gravel',
-      //   group: 'Q1.2',
-      //   url: 'wms',
-      //   popup: gravel_aosPopup,
-      //   layerOptions: {
-      //     layers: 'planning_udp:gravel_aos',
-      //     format: 'image/png',
-      //     minZoom: 18, // default '0' => World View
-      //     maxZoom: 20, // Default '18', Street Level
-      //     keepBuffer: 10,
-      //     tileSize: 256,
-      //     transparent: true
-      //   },
-      //   displayInOverlay: true
-      // },
-      // //   {
-      // //       key: 'Q1.2 - Housing Sites',
-      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:housing_sites&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      // //       layerOptions: {
-      // //           maxZoom: 17,
-      // //           style: housingsitesStyle,
-      // //           onEachFeature: housingsitesPopup
-      // //       }
-      // //   },
-      // {
-      //   key: 'Housing Sites',
-      //   group: 'Q1.2',
-      //   url: 'wms',
-      //   popup: housingsitesPopup,
-      //   layerOptions: {
-      //     layers: 'planning_udp:housing_sites',
-      //     format: 'image/png',
-      //     minZoom: 18, // default '0' => World View
-      //     maxZoom: 20, // Default '18', Street Level
-      //     keepBuffer: 10,
-      //     tileSize: 256,
-      //     transparent: true
-      //   },
-      //   displayInOverlay: true
-      // }
-      //   {
-      //       key: 'Q1.2 - Landscape Character Areas',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:landscape_character_area&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: landscapecharacterareaStyle,
-      //           onEachFeature: landscapecharacterareaPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Local Nature Reserves',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=biota:local_nature_reserves&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: localnaturereserveStyle,
-      //           onEachFeature: localnaturereservePopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Local Open Space',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:local_open_space&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: localopenspaceStyle,
-      //           onEachFeature: localopenspacePopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Local Wildlife Sites',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:local_wildlife_sites&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: localwildlifesitesStyle,
-      //           onEachFeature: localwildlifesitesPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Metrolink Corridor',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:metrolink_corridor&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: metrolinkcorridorStyle,
-      //           onEachFeature: metrolinkcorridorPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - M60 Gateway Sites',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:m60_gateway_sites&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: m60gatewaysitesStyle,
-      //           onEachFeature: m60gatewaysitesPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Parks and Gardens of Historic Interest',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:parkgarden_of_historic_interest&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: parkgardenofhistoricinterestStyle,
-      //           onEachFeature: parkgardenofhistoricinterestPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Policy Guidance Areas',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:pgas&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: pgasStyle,
-      //           onEachFeature: pgasPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Predominantly Residential Area',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:predominantly_residential&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: predominantlyresidentialStyle,
-      //           onEachFeature: predominantlyresidentialPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Relief Road Corridor',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:relief_road_corridor&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: reliefroadcorridorStyle,
-      //           onEachFeature: reliefroadcorridorPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Sand Area of Search',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:sand_aos&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: sandaosStyle,
-      //           onEachFeature: sandaosPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Sandstone/Gritstone Area of Search',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:sandstone_gritstone&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: sandgritaosStyle,
-      //           onEachFeature: sandgritaosPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Shop Frontages',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:shop_frontages&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: shopfrontagesStyle,
-      //           onEachFeature: shopfrontagesPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Shopping Areas - Town Centre',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:shopping_tc&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: shoppingtcStyle,
-      //           onEachFeature: shoppingtcPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Shopping Areas',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:shopping_areas&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: shoppingareasStyle,
-      //           onEachFeature: shoppingareasPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Sites of Biological Importance',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=biota:sbi&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: sbiStyle,
-      //           onEachFeature: sbiPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Sites of Special Scientific Importance',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=biota:sssi&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: sssiStyle,
-      //           onEachFeature: sssiPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Strategic Open Space',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:strategic_open_space&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: strategicopenspaceStyle,
-      //           onEachFeature: strategicopenspacePopup
-      //       }
-      //   },
-        
-      //   {
-      //       key: 'Q1.2 - Strategic Recreation Routes',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:strategic_recreation_routes&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: strategicrecreationroutesStyle,
-      //           onEachFeature: strategicrecreationroutesPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q1.2 - Town Centre Areas',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:town_centre_areas&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: towncentreareasStyle,
-      //           onEachFeature: towncentreareasPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q2.1 - Adopted Highways',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:2_1a&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           style: adopted_highwaysStyle,
-      //           onEachFeature: adopted_highwaysPopup,
-      //           maxZoom: 17
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q2.1 - Section 38 Agreements',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:2_1b&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           style: section38Style,
-      //           onEachFeature: section38Popup,
-      //           maxZoom: 17
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q2.1 - Private Streetworks',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:2_1c&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           style: privatestreetworksStyle,
-      //           onEachFeature: privatestreetworksPopup,
-      //           maxZoom: 17
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q2.2 - Definitive Rights of Way',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=highways:public_rights_of_way&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: prowStyle,
-      //           onEachFeature: prowPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.4a - Trunk Road 200m Buffer',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4a&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: trunk200Style,
-      //           onEachFeature: trunk200Popup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.4b - Road Alterations',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4b&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: roadalterationsStyle,
-      //           onEachFeature: roadalterationsPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.4c - Construction Works',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4c&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: roadalterationsStyle,
-      //           onEachFeature: threefourPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.4d - New Road Construction',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4d&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: newroadStyle,
-      //           onEachFeature: threefourPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.4e - Proposed New Road Consultation',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4e&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: newroadconsultStyle,
-      //           onEachFeature: newroadconsultPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.4f - Road Alterations',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4f&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: roadalterationsStyle,
-      //           onEachFeature: threefourPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.5 - Proposed Railway Scheme Buffered',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_5&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: newrailwayStyle,
-      //           onEachFeature: newrailwayPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.6 - Waiting or Loading Restrictions 200m Buffer',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6b&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: waitingStyle,
-      //           onEachFeature: waitingPopup
-      //       }
-      //   },
-        
-      //   {
-      //       key: 'Q3.6 - One Way 200m Buffer',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6c&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: onewayStyle,
-      //           onEachFeature: onewayPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.6 - Prohibition of Driving 200m Buffer',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6d&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: prohibitionofdrivingStyle,
-      //           onEachFeature: prohibitionofdrivingPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.6 - Pedestrianisation 200m Buffer',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6e&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: pedestrianisationStyle,
-      //           onEachFeature: pedestrianisationPopup
-      //       }
-      //   },
-        
-      //   {
-      //       key: 'Q3.6 - Width or Weight Restriction 200m Buffer',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6f&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: widthweightStyle,
-      //           onEachFeature: widthweightPopup
-      //       }
-      //   },
-        
-      //   {
-      //       key: 'Q3.6 - Traffic Calming 200m Buffer',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6g&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: trafficcalmingStyle,
-      //           onEachFeature: trafficcalmingPopup
-      //       }
-      //   },
-        
-      //   {
-      //       key: 'Q3.6 - Residents Parking Controls Buffered',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6h&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: residentsparkingStyle,
-      //           onEachFeature: residentsparkingPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.6 - Minor Road Alteration Buffered',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6i&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: minorroadalterationsStyle,
-      //           onEachFeature: minorroadalterationsPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.6 - Cycle Track Buffered',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6k&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: cycletrackStyle,
-      //           onEachFeature: cycletrackPopup
-      //       }
-      //   },
-
-      //  {
-      //     key: 'Q3.9 - Enforcement Notice Buffered',
-      //     url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9a&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //     layerOptions: {
-      //           maxZoom: 17,
-      //           style: enforcementnoticeStyle,
-      //           onEachFeature: enforcementnoticePopup
-      //   }
-        
-      //   },
-
-      //   {
-      //       key: 'Q3.9 - Stop Notice Buffered',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9b&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: stopnoticeStyle,
-      //           onEachFeature: stopnoticePopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.9 - Listed Building Enforcement Notice',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9c&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: listbuildingenfStyle,
-      //           onEachFeature: listbuildingenfPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.9 - Breach of Condition Notice',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9d&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: breachconditionStyle,
-      //           onEachFeature: breachconditionPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.9 - Planning Contravention Notice',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9e&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: planningcontraStyle,
-      //           onEachFeature: planningcontraPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.9 - Other Notice',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9f&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: othernoticeStyle,
-      //           onEachFeature: othernoticePopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.9 - Tree Preservation Orders',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9m&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: tpoStyle,
-      //           onEachFeature: tpoPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.12 - Compulsory Purchase Order',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_12&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: cpoStyle,
-      //           onEachFeature: cpoPopup
-      //       }
-      //   },
-
-      //   {
-      //       key: 'Q3.14 - Radon Gas',
-      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_14&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
-      //       layerOptions: {
-      //           maxZoom: 17,
-      //           style: radonStyle,
-      //           onEachFeature: radonPopup
-      //       }
-      //   }
-
-    ]
+  ]
 }
 
 export default Configuration

--- a/Configuration/con29-wms/index.js
+++ b/Configuration/con29-wms/index.js
@@ -1,0 +1,806 @@
+import { 
+  buildingregsapprovalPopup,
+  buildingcertPopup,
+  conservationareaPopup
+} from './Popups'
+
+// Leaflet default '0' => World View
+const minZoom = 12 // (Zoom out to - Street Level)
+
+// Leaflet default '18' => Street Level
+const maxZoom = 20 // (Zoom down to - House View)
+
+// IF all layers have the same constraints
+// Specify "LayerVisibleFrom / ...To" within "Map"
+// OR specify "minZoom / maxZoom" on each layer
+const Configuration = {
+  Map: {
+    StartingZoom: 19,
+    LayersVisibleFrom: minZoom,
+    LayersVisibleTo: maxZoom
+  },
+  Tiles: { Token: '3G26OzBg7XRROryDwG1o1CZRmIx66ulo' },
+  DynamicData: 
+  [
+    {
+      key: 'Planning Applications',
+      url: 'wms',
+      layerOptions: {
+        layers: 'con29:planning_applications_con29', // planning:green_belt_os
+        // minZoom: 12,
+        popup: {
+          // title: 'Custom Title - Planning Applications', // or taken from "Group" + "Key" -or- just "Key" if no group specified
+          icon: 'fa fa-building',
+          body: {
+            'Planning Application No.': 'refval',
+            'Address': 'address',
+            'App Type': 'application_type',
+            'Proposal': 'proposal',
+            'Decision': 'decision',
+            'Decision Date': 'decision_date'
+          }
+        }
+      },
+    },
+    {
+      key: 'Building Regulations Approval',
+      url: 'wms',
+      layerOptions: {
+        layers: 'con29:1_1j',
+        popup: buildingregsapprovalPopup
+      }
+    },
+    {
+      key: 'Building Certificate',
+      url: 'wms',
+      layerOptions: {
+        layers: 'con29:1_1k',
+        popup: buildingcertPopup
+      }
+    },
+    {
+      key: 'Airport Public Safety Zone',
+      url: 'wms',
+      layerOptions: {
+        layers: 'planning:airport_public_safety_zone',
+        popup: {
+          icon: 'fa fa-plane',
+          body: { 'Policy': 'policy' }
+        }
+      }
+    },
+    {
+      key: 'Ancient Monuments',
+      url: 'wms',
+      layerOptions: {
+        layers: 'heritage:ancient_monument',
+        popup: {
+          icon: 'fa fa-flag',
+          body: {
+            'Name': 'name',
+            'National Monument No': 'national_monument_no'
+          }
+        }
+      }
+    },
+    {
+      key: 'Conservation Areas',
+      url: 'wms',
+      layerOptions: {
+        layers: 'heritage:conservation_area',
+        popup: conservationareaPopup
+      }
+    },
+    {
+      key: 'Employment Areas',
+      url: 'wms',
+      layerOptions: {
+        layers: 'planning_udp:employment_areas',
+        popup: {
+          icon: 'fa fa-briefcase',
+          body: {
+            'ID': 'id',
+            'Name': 'name',
+            'Name': 'policy'
+          }
+        }  
+      }
+    },
+    {
+      key: 'Employment Proposed',
+      url: 'wms',
+      layerOptions: {
+        layers: 'planning_udp:employment_proposed',
+        popup: {
+          icon: 'fa fa-briefcase',
+          body: {
+            'ID': 'id',
+            'Name': 'policy'
+          }
+        }
+      }
+    },
+    {
+      key: 'Definitive Rights of Way',
+      url: 'wms',
+      layerOptions: {
+        layers: 'highways:public_rights_of_way',
+        popup: {
+          icon: 'fa fa-map-signs',
+          body: {
+            'PROW Number': 'row',
+            'Type': 'type'
+          }
+        }
+      }
+    }
+    // {
+    //     key: 'Q1.2 - Flood Zones',
+    //     url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=flooding:flood_zones&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+    //     layerOptions: {
+    //         maxZoom: 17,
+    //         style: floodzonesStyle,
+    //         onEachFeature: floodzonesPopup
+    //     }
+    // },
+      // {
+      //   key: 'Flood Zones',
+      //   group: 'Q1.2',
+      //   url: 'wms',
+      //   popup: floodzonesPopup,
+      //   layerOptions: {
+      //     layers: 'flooding:flood_zones',
+      //     format: 'image/png',
+      //     minZoom: 18, // default '0' => World View
+      //     maxZoom: 20, // Default '18', Street Level
+      //     keepBuffer: 10,
+      //     tileSize: 256,
+      //     transparent: true
+      //   },
+      //   displayInOverlay: true
+      // },
+      // //   {
+      // //       key: 'Q1.2 - Green Belt',
+      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning:green_belt_os&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      // //       layerOptions: {
+      // //           maxZoom: 17,
+      // //           style: greenbeltStyle,
+      // //           onEachFeature: greenbeltPopup
+      // //       }
+      // //   },
+      // {
+      //   key: 'Green Belt',
+      //   group: 'Q1.2',
+      //   url: 'wms',
+      //   popup: greenbeltPopup,
+      //   layerOptions: {
+      //     layers: 'planning:green_belt_os',
+      //     format: 'image/png',
+      //     minZoom: 18, // default '0' => World View
+      //     maxZoom: 20, // Default '18', Street Level
+      //     keepBuffer: 10,
+      //     tileSize: 256,
+      //     transparent: true
+      //   },
+      //   displayInOverlay: true
+      // },
+      // //   {
+      // //       key: 'Q1.2 - Major Existing Development Sites in the Green Belt (MEDS)',
+      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:greenbelt_meds&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      // //       layerOptions: {
+      // //           maxZoom: 17,
+      // //           style: greenbeltmedsStyle,
+      // //           onEachFeature: greenbeltmedsPopup
+      // //       }
+      // //   },
+      // {
+      //   key: 'Major Existing Development Sites in the Green Belt (MEDS)',
+      //   group: 'Q1.2',
+      //   url: 'wms',
+      //   popup: greenbeltmedsPopup,
+      //   layerOptions: {
+      //     layers: 'planning_udp:greenbelt_meds',
+      //     format: 'image/png',
+      //     minZoom: 18, // default '0' => World View
+      //     maxZoom: 20, // Default '18', Street Level
+      //     keepBuffer: 10,
+      //     tileSize: 256,
+      //     transparent: true
+      //   },
+      //   displayInOverlay: true
+      // },
+      // //   {
+      // //       key: 'Q1.2 - General',
+      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:general&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      // //       layerOptions: {
+      // //           maxZoom: 17,
+      // //           style: generalStyle,
+      // //           onEachFeature: generalPopup
+      // //       }
+      // //   },
+      // {
+      //   key: 'General',
+      //   group: 'Q1.2',
+      //   url: 'wms',
+      //   popup: generalPopup,
+      //   layerOptions: {
+      //     layers: 'planning_udp:general',
+      //     format: 'image/png',
+      //     minZoom: 18, // default '0' => World View
+      //     maxZoom: 20, // Default '18', Street Level
+      //     keepBuffer: 10,
+      //     tileSize: 256,
+      //     transparent: true
+      //   },
+      //   displayInOverlay: true
+      // },
+      // //   {
+      // //       key: 'Q1.2 - Green Chain',
+      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:green_chain&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      // //       layerOptions: {
+      // //           maxZoom: 17,
+      // //           style: greenchainStyle,
+      // //           onEachFeature: greenchainPopup
+      // //       }
+      // //   },
+      // {
+      //   key: 'Green Chain',
+      //   group: 'Q1.2',
+      //   url: 'wms',
+      //   popup: greenchainPopup,
+      //   layerOptions: {
+      //     layers: 'planning_udp:green_chain',
+      //     format: 'image/png',
+      //     minZoom: 18, // default '0' => World View
+      //     maxZoom: 20, // Default '18', Street Level
+      //     keepBuffer: 10,
+      //     tileSize: 256,
+      //     transparent: true
+      //   },
+      //   displayInOverlay: true
+      // },
+      // //   {
+      // //       key: 'Q1.2 - Gravel',
+      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:gravel_aos&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      // //       layerOptions: {
+      // //           maxZoom: 17,
+      // //           style: gravel_aosStyle,
+      // //           onEachFeature: gravel_aosPopup
+      // //       }
+      // //   },
+      // {
+      //   key: 'Gravel',
+      //   group: 'Q1.2',
+      //   url: 'wms',
+      //   popup: gravel_aosPopup,
+      //   layerOptions: {
+      //     layers: 'planning_udp:gravel_aos',
+      //     format: 'image/png',
+      //     minZoom: 18, // default '0' => World View
+      //     maxZoom: 20, // Default '18', Street Level
+      //     keepBuffer: 10,
+      //     tileSize: 256,
+      //     transparent: true
+      //   },
+      //   displayInOverlay: true
+      // },
+      // //   {
+      // //       key: 'Q1.2 - Housing Sites',
+      // //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:housing_sites&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      // //       layerOptions: {
+      // //           maxZoom: 17,
+      // //           style: housingsitesStyle,
+      // //           onEachFeature: housingsitesPopup
+      // //       }
+      // //   },
+      // {
+      //   key: 'Housing Sites',
+      //   group: 'Q1.2',
+      //   url: 'wms',
+      //   popup: housingsitesPopup,
+      //   layerOptions: {
+      //     layers: 'planning_udp:housing_sites',
+      //     format: 'image/png',
+      //     minZoom: 18, // default '0' => World View
+      //     maxZoom: 20, // Default '18', Street Level
+      //     keepBuffer: 10,
+      //     tileSize: 256,
+      //     transparent: true
+      //   },
+      //   displayInOverlay: true
+      // }
+      //   {
+      //       key: 'Q1.2 - Landscape Character Areas',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:landscape_character_area&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: landscapecharacterareaStyle,
+      //           onEachFeature: landscapecharacterareaPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Local Nature Reserves',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=biota:local_nature_reserves&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: localnaturereserveStyle,
+      //           onEachFeature: localnaturereservePopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Local Open Space',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:local_open_space&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: localopenspaceStyle,
+      //           onEachFeature: localopenspacePopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Local Wildlife Sites',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:local_wildlife_sites&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: localwildlifesitesStyle,
+      //           onEachFeature: localwildlifesitesPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Metrolink Corridor',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:metrolink_corridor&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: metrolinkcorridorStyle,
+      //           onEachFeature: metrolinkcorridorPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - M60 Gateway Sites',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:m60_gateway_sites&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: m60gatewaysitesStyle,
+      //           onEachFeature: m60gatewaysitesPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Parks and Gardens of Historic Interest',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=heritage:parkgarden_of_historic_interest&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: parkgardenofhistoricinterestStyle,
+      //           onEachFeature: parkgardenofhistoricinterestPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Policy Guidance Areas',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:pgas&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: pgasStyle,
+      //           onEachFeature: pgasPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Predominantly Residential Area',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:predominantly_residential&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: predominantlyresidentialStyle,
+      //           onEachFeature: predominantlyresidentialPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Relief Road Corridor',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:relief_road_corridor&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: reliefroadcorridorStyle,
+      //           onEachFeature: reliefroadcorridorPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Sand Area of Search',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:sand_aos&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: sandaosStyle,
+      //           onEachFeature: sandaosPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Sandstone/Gritstone Area of Search',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:sandstone_gritstone&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: sandgritaosStyle,
+      //           onEachFeature: sandgritaosPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Shop Frontages',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:shop_frontages&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: shopfrontagesStyle,
+      //           onEachFeature: shopfrontagesPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Shopping Areas - Town Centre',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:shopping_tc&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: shoppingtcStyle,
+      //           onEachFeature: shoppingtcPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Shopping Areas',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:shopping_areas&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: shoppingareasStyle,
+      //           onEachFeature: shoppingareasPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Sites of Biological Importance',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=biota:sbi&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: sbiStyle,
+      //           onEachFeature: sbiPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Sites of Special Scientific Importance',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=biota:sssi&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: sssiStyle,
+      //           onEachFeature: sssiPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Strategic Open Space',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:strategic_open_space&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: strategicopenspaceStyle,
+      //           onEachFeature: strategicopenspacePopup
+      //       }
+      //   },
+        
+      //   {
+      //       key: 'Q1.2 - Strategic Recreation Routes',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:strategic_recreation_routes&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: strategicrecreationroutesStyle,
+      //           onEachFeature: strategicrecreationroutesPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q1.2 - Town Centre Areas',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=planning_udp:town_centre_areas&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: towncentreareasStyle,
+      //           onEachFeature: towncentreareasPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q2.1 - Adopted Highways',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:2_1a&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           style: adopted_highwaysStyle,
+      //           onEachFeature: adopted_highwaysPopup,
+      //           maxZoom: 17
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q2.1 - Section 38 Agreements',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:2_1b&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           style: section38Style,
+      //           onEachFeature: section38Popup,
+      //           maxZoom: 17
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q2.1 - Private Streetworks',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:2_1c&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           style: privatestreetworksStyle,
+      //           onEachFeature: privatestreetworksPopup,
+      //           maxZoom: 17
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q2.2 - Definitive Rights of Way',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=highways:public_rights_of_way&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: prowStyle,
+      //           onEachFeature: prowPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.4a - Trunk Road 200m Buffer',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4a&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: trunk200Style,
+      //           onEachFeature: trunk200Popup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.4b - Road Alterations',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4b&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: roadalterationsStyle,
+      //           onEachFeature: roadalterationsPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.4c - Construction Works',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4c&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: roadalterationsStyle,
+      //           onEachFeature: threefourPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.4d - New Road Construction',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4d&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: newroadStyle,
+      //           onEachFeature: threefourPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.4e - Proposed New Road Consultation',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4e&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: newroadconsultStyle,
+      //           onEachFeature: newroadconsultPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.4f - Road Alterations',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_4f&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: roadalterationsStyle,
+      //           onEachFeature: threefourPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.5 - Proposed Railway Scheme Buffered',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_5&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: newrailwayStyle,
+      //           onEachFeature: newrailwayPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.6 - Waiting or Loading Restrictions 200m Buffer',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6b&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: waitingStyle,
+      //           onEachFeature: waitingPopup
+      //       }
+      //   },
+        
+      //   {
+      //       key: 'Q3.6 - One Way 200m Buffer',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6c&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: onewayStyle,
+      //           onEachFeature: onewayPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.6 - Prohibition of Driving 200m Buffer',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6d&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: prohibitionofdrivingStyle,
+      //           onEachFeature: prohibitionofdrivingPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.6 - Pedestrianisation 200m Buffer',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6e&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: pedestrianisationStyle,
+      //           onEachFeature: pedestrianisationPopup
+      //       }
+      //   },
+        
+      //   {
+      //       key: 'Q3.6 - Width or Weight Restriction 200m Buffer',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6f&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: widthweightStyle,
+      //           onEachFeature: widthweightPopup
+      //       }
+      //   },
+        
+      //   {
+      //       key: 'Q3.6 - Traffic Calming 200m Buffer',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6g&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: trafficcalmingStyle,
+      //           onEachFeature: trafficcalmingPopup
+      //       }
+      //   },
+        
+      //   {
+      //       key: 'Q3.6 - Residents Parking Controls Buffered',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6h&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: residentsparkingStyle,
+      //           onEachFeature: residentsparkingPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.6 - Minor Road Alteration Buffered',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6i&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: minorroadalterationsStyle,
+      //           onEachFeature: minorroadalterationsPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.6 - Cycle Track Buffered',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_6k&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: cycletrackStyle,
+      //           onEachFeature: cycletrackPopup
+      //       }
+      //   },
+
+      //  {
+      //     key: 'Q3.9 - Enforcement Notice Buffered',
+      //     url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9a&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //     layerOptions: {
+      //           maxZoom: 17,
+      //           style: enforcementnoticeStyle,
+      //           onEachFeature: enforcementnoticePopup
+      //   }
+        
+      //   },
+
+      //   {
+      //       key: 'Q3.9 - Stop Notice Buffered',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9b&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: stopnoticeStyle,
+      //           onEachFeature: stopnoticePopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.9 - Listed Building Enforcement Notice',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9c&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: listbuildingenfStyle,
+      //           onEachFeature: listbuildingenfPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.9 - Breach of Condition Notice',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9d&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: breachconditionStyle,
+      //           onEachFeature: breachconditionPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.9 - Planning Contravention Notice',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9e&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: planningcontraStyle,
+      //           onEachFeature: planningcontraPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.9 - Other Notice',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9f&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: othernoticeStyle,
+      //           onEachFeature: othernoticePopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.9 - Tree Preservation Orders',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_9m&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: tpoStyle,
+      //           onEachFeature: tpoPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.12 - Compulsory Purchase Order',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_12&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: cpoStyle,
+      //           onEachFeature: cpoPopup
+      //       }
+      //   },
+
+      //   {
+      //       key: 'Q3.14 - Radon Gas',
+      //       url: 'https://spatial.stockport.gov.uk/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=con29:3_14&outputFormat=application/json&bbox={0},EPSG:4326&srsName=EPSG:4326',
+      //       layerOptions: {
+      //           maxZoom: 17,
+      //           style: radonStyle,
+      //           onEachFeature: radonPopup
+      //       }
+      //   }
+
+    ]
+}
+
+export default Configuration

--- a/src/App.js
+++ b/src/App.js
@@ -56,7 +56,7 @@ function App() {
     if (DynamicData !== undefined) {
       var wfsLayers = DynamicData.filter(layer => !layer.url.endsWith('wms?'))
       if (wfsLayers.length > 0) {
-        mapRef.current.on('zoomend moveend', () => reloadDynamicWFSLayers(wfsLayers, DynamicLayerGroup, mapRef.current))
+        mapRef.current.on('moveend', () => reloadDynamicWFSLayers(wfsLayers, DynamicLayerGroup, mapRef.current))
       }
     }
   }, [mapRef])

--- a/src/App.js
+++ b/src/App.js
@@ -125,12 +125,9 @@ function App() {
         return `${acc} ${curr._popup._content} ${index != src.length - 1 ? '<hr/>' : ''}`
       }, '')
 
-    if (layerContentInMap && 
-        _popup !== null && 
-        _popup._content !== null && 
-        !layerContentInMap.includes(_popup._content)) {
-        layerContentInMap += `<hr/>${_popup._content}`
-      }
+    if (layerContentInMap && _popup !== null && _popup._content !== null && !layerContentInMap.includes(_popup._content)) {
+      layerContentInMap += `<hr/>${_popup._content}`
+    }
 
     /** opens new popup with new content and binds to map, this is instead of using 
      * mapRef.current._popup.setConent as the popup is bound to the layer and not 

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,6 @@ import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css'
 function App() {
   const { Map, DynamicData, StaticData, LayerControlOptions } = Config
   const mapRef = useRef()
-  const WMSLayerGroup = {}
   const DynamicLayerGroup = DynamicData == undefined ? [] : DynamicData.reduce(
     (accumulator, currentValue) => {
       accumulator[currentValue.key] = new Leaflet.FeatureGroup()
@@ -109,7 +108,10 @@ function App() {
   const [onClickLatLng, setOnClickLatLng] = useState()
 
   useEffect(() => {
-    mapRef.current.on('click', e => layersFeatureInfoPopup(e, DynamicData, mapRef.current))
+    var wmsLayersWithPopup = DynamicData.filter(layer => layer.url.endsWith('wms?') && layer.layerOptions.popup !== undefined)
+    if (wmsLayersWithPopup.length > 0) {
+      mapRef.current.on('click', e => layersFeatureInfoPopup(e, wmsLayersWithPopup, mapRef.current))
+    }
   }, [mapRef.current])
 
   useEffect(() => {

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -30,36 +30,29 @@ const defaultLayerControlOptions = {
   keyGraphic: false
 }
 
-// ADDITIONS ... 
-
-// LatLng {lat: 53.35464982868248, lng: -2.384719848632813}, LatLng {lat: 53.50887634379406, lng: -1.8573760986328127}
-const mapMaxBounds: Array<Array<number>> = [[53.2, -2.4],[53.5, -1.9]]
+const mapMaxBounds: Array<Array<number>> = [[53.15, -2.88],[53.62, -1.37]]
 
 // WMS layer
 const wmsUrl: string = 'https://spatial.stockport.gov.uk/geoserver/wms?'
 const format: string = 'image/png'
-const tileBuffer: number = 10
 const tileSize: number = 256
 const transparent: boolean = true
 
 const processDataLayer = (layer) => {
-  var wms = layer.url === 'wms'
-
   const baseLayer = {
     displayInOverlay: defaultdisplayInOverlay,
     visibleByDefault: defaultVisibleByDefault,
     layerOptions: {
       minZoom: Map.LayersVisibleFrom ?? defaultLayerMaxZoom,
-      maxZoom: Map.LayersVisibleTo ?? defaultLayerMinZoom
+      maxZoom: Map.LayersVisibleTo ?? defaultLayerMinZoom,
+      format: layer.layerOptions.format ?? format,
+      tileSize: layer.layerOptions.tileSize ?? tileSize,
+      transparent: layer.layerOptions.transparent ?? transparent
     }
   }
 
-  if (wms) {
+  if (layer.url === 'wms') {
     layer.url = wmsUrl
-    layer.layerOptions.format = format
-    layer.layerOptions.keepBuffer = tileBuffer
-    layer.layerOptions.tileSize = tileSize
-    layer.layerOptions.transparent = transparent
 
   } else {
     // Switch zooms around
@@ -67,6 +60,7 @@ const processDataLayer = (layer) => {
     var maxZoom = layer.layerOptions.minZoom ?? defaultLayerMinZoom
     layer.layerOptions.minZoom = minZoom
     layer.layerOptions.maxZoom = maxZoom
+
   }
 
   return { ...baseLayer, ...layer, layerOptions: { ...baseLayer.layerOptions, ...layer.layerOptions } }
@@ -116,23 +110,23 @@ if (displayOS1250) {
 }
 
 export default {
-    Map: {
-        StartingLatLng: [latitude, longitude],
-        MaxBounds: mapMaxBounds, 
-        Zoom: defaultStartZoom,
-        MinZoom: defaultMinimumZoom,
-        EnableLocateControl: enableLocateControl,
-        EmbeddedInForm: embeddedInForm,
-        Class: mapClass,
-        MapClickMinZoom: mapClickMinZoom,
-        DisplayBoundary: displayBoundary,
-        HasMapClickFunction: hasMapClickFunction,
-        HasMapLoadFunction: hasMapLoadFunction,
-        OnMapClick: Map.OnMapClick,
-        OnMapLoad: Map.OnMapLoad,
-        HasAllowZoomToLocation: hasAllowZoomToLocationOnLoad,
-        EnableGestureControl: enableGestureControl
-    },
+  Map: {
+    StartingLatLng: [latitude, longitude],
+    MaxBounds: mapMaxBounds, 
+    Zoom: defaultStartZoom,
+    MinZoom: defaultMinimumZoom,
+    EnableLocateControl: enableLocateControl,
+    EmbeddedInForm: embeddedInForm,
+    Class: mapClass,
+    MapClickMinZoom: mapClickMinZoom,
+    DisplayBoundary: displayBoundary,
+    HasMapClickFunction: hasMapClickFunction,
+    HasMapLoadFunction: hasMapLoadFunction,
+    OnMapClick: Map.OnMapClick,
+    OnMapLoad: Map.OnMapLoad,
+    HasAllowZoomToLocation: hasAllowZoomToLocationOnLoad,
+    EnableGestureControl: enableGestureControl
+  },
   Tiles: { Token: Tiles.Token },
   LayerControlOptions: Object.assign(defaultLayerControlOptions, LayerControlOptions),
   DynamicData: dynamicData,

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -30,14 +30,43 @@ const defaultLayerControlOptions = {
   keyGraphic: false
 }
 
+// ADDITIONS ... 
+
+// LatLng {lat: 53.35464982868248, lng: -2.384719848632813}, LatLng {lat: 53.50887634379406, lng: -1.8573760986328127}
+const mapMaxBounds: Array<Array<number>> = [[53.2, -2.4],[53.5, -1.9]]
+
+// WMS layer
+const wmsUrl: string = 'https://spatial.stockport.gov.uk/geoserver/wms?'
+const format: string = 'image/png'
+const tileBuffer: number = 10
+const tileSize: number = 256
+const transparent: boolean = true
+
 const processDataLayer = (layer) => {
+  var wms = layer.url === 'wms'
+
   const baseLayer = {
     displayInOverlay: defaultdisplayInOverlay,
     visibleByDefault: defaultVisibleByDefault,
     layerOptions: {
-      maxZoom: defaultLayerMaxZoom,
-      minZoom: defaultLayerMinZoom
+      minZoom: Map.LayersVisibleFrom ?? defaultLayerMaxZoom,
+      maxZoom: Map.LayersVisibleTo ?? defaultLayerMinZoom
     }
+  }
+
+  if (wms) {
+    layer.url = wmsUrl
+    layer.layerOptions.format = format
+    layer.layerOptions.keepBuffer = tileBuffer
+    layer.layerOptions.tileSize = tileSize
+    layer.layerOptions.transparent = transparent
+
+  } else {
+    // Switch zooms around
+    var minZoom = layer.layerOptions.maxZoom ?? defaultLayerMaxZoom
+    var maxZoom = layer.layerOptions.minZoom ?? defaultLayerMinZoom
+    layer.layerOptions.minZoom = minZoom
+    layer.layerOptions.maxZoom = maxZoom
   }
 
   return { ...baseLayer, ...layer, layerOptions: { ...baseLayer.layerOptions, ...layer.layerOptions } }
@@ -73,35 +102,37 @@ if (displayBoundary) {
 if (displayOS1250) {
   dynamicData.push({
     key: 'os1250_line',
-    url: 'http://spatial.stockport.gov.uk/geoserver/wms?',
+    url: wmsUrl,
     layerOptions: {
       maxZoom: 20,
       minZoom: os1250MinZoom,
       layers: 'base_maps:os1250_line,base_maps:os1250_text',
       format: 'image/png',
-      transparent: true
+      transparent: true,
+      zIndex: 1000
     },
     displayInOverlay: false
   })
 }
 
 export default {
-  Map: {
-    StartingLatLng: [latitude, longitude],
-    Zoom: defaultStartZoom,
-    MinZoom: defaultMinimumZoom,
-    EnableLocateControl: enableLocateControl,
-    EmbeddedInForm: embeddedInForm,
-    Class: mapClass,
-    MapClickMinZoom: mapClickMinZoom,
-    DisplayBoundary: displayBoundary,
-    HasMapClickFunction: hasMapClickFunction,
-    HasMapLoadFunction: hasMapLoadFunction,
-    OnMapClick: Map.OnMapClick,
-    OnMapLoad: Map.OnMapLoad,
-    HasAllowZoomToLocation: hasAllowZoomToLocationOnLoad,
-    EnableGestureControl: enableGestureControl
-  },
+    Map: {
+        StartingLatLng: [latitude, longitude],
+        MaxBounds: mapMaxBounds, 
+        Zoom: defaultStartZoom,
+        MinZoom: defaultMinimumZoom,
+        EnableLocateControl: enableLocateControl,
+        EmbeddedInForm: embeddedInForm,
+        Class: mapClass,
+        MapClickMinZoom: mapClickMinZoom,
+        DisplayBoundary: displayBoundary,
+        HasMapClickFunction: hasMapClickFunction,
+        HasMapLoadFunction: hasMapLoadFunction,
+        OnMapClick: Map.OnMapClick,
+        OnMapLoad: Map.OnMapLoad,
+        HasAllowZoomToLocation: hasAllowZoomToLocationOnLoad,
+        EnableGestureControl: enableGestureControl
+    },
   Tiles: { Token: Tiles.Token },
   LayerControlOptions: Object.assign(defaultLayerControlOptions, LayerControlOptions),
   DynamicData: dynamicData,

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -30,7 +30,7 @@ const defaultLayerControlOptions = {
   keyGraphic: false
 }
 
-const mapMaxBounds: Array<Array<number>> = [[53.15, -2.88],[53.62, -1.37]]
+const mapMaxBounds: Array<Array<number>> = Map.MaxBounds ?? [[53.15, -2.88],[53.62, -1.37]]
 
 // WMS layer
 const wmsUrl: string = 'https://spatial.stockport.gov.uk/geoserver/wms?'

--- a/src/Controls/index.js
+++ b/src/Controls/index.js
@@ -13,45 +13,29 @@ const AddLayerControlsLayers = () => (
   }
 )
 
-const AddWMSLayers = (overlays, WMSLayerGroup, mapRef) => {
-  Object.keys(WMSLayerGroup).map((layer) => {
-    const layerDetails = WMSLayerGroup[layer]
-    var wmsLayer = new Leaflet.tileLayer.wms(layerDetails.url, layerDetails.layerOptions)
-    if (layerDetails.displayInOverlay) {
-      overlays[layer] = wmsLayer
-    } else {
-      wmsLayer.addTo(mapRef)
-    }
-  })
-
-  return overlays
-}
-
-const AddLayerControlsOverlays = (DynamicData, DynamicLayerGroup, WMSLayerGroup, mapRef) => {
+const AddLayerControlsOverlays = (DynamicData, DynamicLayerGroup) => {
   let overlays = {}
   if (DynamicData == null) {
-    return AddWMSLayers(overlays, WMSLayerGroup, mapRef)
+    return overlays
   }
 
   for (var x = 0; x < DynamicData.length; x++) {
     let layer = DynamicData[x]
-    if (layer.displayInOverlay) {
-      if (!layer.group) {
-        overlays[layer.key] = DynamicLayerGroup[layer.key]
-      } else {
-        if (!overlays[layer.group]) {
-          overlays[layer.group] = {}
-        }
-        overlays[layer.group][layer.key] = DynamicLayerGroup[layer.key]
-      }
+    if (!layer.displayInOverlay) {
+      continue
     }
 
-    if (layer.visibleByDefault) {
-      DynamicLayerGroup[layer.key].addTo(mapRef)
+    if (!layer.group) {
+      overlays[layer.key] = DynamicLayerGroup[layer.key]
+    } else {
+      if (!overlays[layer.group]) {
+        overlays[layer.group] = {}
+      }
+      overlays[layer.group][layer.key] = DynamicLayerGroup[layer.key]
     }
   }
 
-  return AddWMSLayers(overlays, WMSLayerGroup, mapRef)
+  return overlays
 }
 
 const SearchControlOverlay = (MapConfig, map) => {
@@ -108,9 +92,9 @@ const addKeyGraphicsToOverlays = (overlays, DynamicData) => {
   }
 }
 
-const setLayerControls = (DynamicData, DynamicLayerGroup, WMSLayerGroup, map, options) => {
+const setLayerControls = (DynamicData, DynamicLayerGroup, map, options) => {
   const controlLayers = AddLayerControlsLayers()
-  const overlays = AddLayerControlsOverlays(DynamicData, DynamicLayerGroup, WMSLayerGroup, map)
+  const overlays = AddLayerControlsOverlays(DynamicData, DynamicLayerGroup, map)
   if (options.keyGraphic) {
     addKeyGraphicsToOverlays(overlays, DynamicData)
   }
@@ -120,7 +104,7 @@ const setLayerControls = (DynamicData, DynamicLayerGroup, WMSLayerGroup, map, op
 
 const setStaticLayers = async (StaticData, Map) => {
   if (StaticData !== undefined) {
-    const layers = {}
+    const layers = {} 
     const StaticLayerGroup = {}
     await Promise.all(
       StaticData.map(async layer => {

--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -25,7 +25,7 @@ const _popUp = (layer, properties) => {
 const toLegendOptions = (givenOptions, withoutTitle) => {
   var legendOptionsString = ''
   var possibleLegendOptions = {
-    fontName: "opensans", // Font to be used for rule titles. The font must be available on the server
+    fontName: null, // Font to be used for rule titles. The font must be available on the server
     fontStyle: null, // 'italic' or 'bold'
     fontSize: null, // Font size for the various text elements. Default size is 12.
     fontColor: null, //  (hex) Set the color for the text of rules and labels

--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -43,34 +43,19 @@ const getFeatureInfo = (point, layer, bbox, x, y) => {
   &INFO_FORMAT=application/json`
   
   return fetch(encodeURI(url.replace(/\s/g,'')))
-  .then(response => response.json())
-  .then(data => data.features !== undefined ? 
-    data.features.map(feature => _popUp(layer, feature.properties)).join('') : '')
-  .catch(error => console.error(error))
+    .then(response => response.json())
+    .then(data => data.features !== undefined ? 
+      data.features.map(feature => _popUp(layer, feature.properties)).join('') : '')
+    .catch(error => console.error(error))
+}
 
-  // WFS : GetFeature
-  // (west)lng, (south)lat, (east)lng, (north)lat
-  // e.latlng.lng, e.latlng.lat, e.latlng.lng, e.latlng.lat
-  // var west = (Number.parseFloat(e.latlng.lng) - Number.parseFloat(0.000000001)).toFixed(9)
-  // var south = (Number.parseFloat(e.latlng.lat) - Number.parseFloat(0.000000001)).toFixed(9)
-  // var east = (Number.parseFloat(e.latlng.lng) + Number.parseFloat(0.000000001)).toFixed(9)
-  // var north = (Number.parseFloat(e.latlng.lat) + Number.parseFloat(0.000000001)).toFixed(9)
-  // var bbox = `${west},${south},${east},${north}`
-  // featureInfo = features.map(feature => {
-  //   var url = `
-  //   https://spatial.stockport.gov.uk/geoserver/wfs?
-  //   service=WFS&version=1.1.0
-  //   &request=GetFeature
-  //   &typeName=${feature}
-  //   &outputFormat=application/json
-  //   &srsName=EPSG:4326
-  //   &bbox=${bbox},EPSG:4326
-  //   `
-    
-  //   fetch(encodeURI(url.replace(/\s/g,'')))
-  //   .then(response => response.json())
-  //   .then(data => feature = layer.popup(data.features))
-  // })
+const swapLayers = (layerGroup, url, bbox, layerOptions) => {
+  fetch(url.replace('{0}', bbox))
+    .then(response => response.json())
+    .then(data => {
+      layerGroup.clearLayers()
+      layerGroup.addLayer(Leaflet.geoJson(data, layerOptions))
+    })
 }
 
 const loadLayer = (layerGroup, url, bbox, layerOptions) => {
@@ -221,5 +206,7 @@ export {
   loadLayer,
   fetchData,
   fetchAddressData,
-  getQueryStringParams
+  getQueryStringParams,
+  keyByType,
+  swapLayers
 }

--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -1,20 +1,94 @@
 import fetch from 'cross-fetch'
 import Leaflet from 'leaflet'
 
-const fetchData = async (url, layerOptions, mapRef, isStaticLayer) => {
-    var currentZoom = mapRef.getZoom()
-    if (isStaticLayer || (currentZoom >= layerOptions.maxZoom && currentZoom <= layerOptions.minZoom)) {
-        const response = await fetchWithTimeout(url)
-        const body = await response.json()
-        return Leaflet.geoJson(body, layerOptions)
-    }
-    return null
+const _popUp = (layer, properties) => {
+  var popup = layer.layerOptions.popup
+
+  if (typeof popup == 'function') {
+    return popup(properties)
+  }
+  var icon = popup?.icon !== undefined ?
+   `<i class="${popup.icon} smbc-map__item__header__block__icon" aria-hidden="true"></i>` 
+   : ''
+
+  var title = popup.title ?? layer.group !== undefined ? `${layer.group} - ${layer.key}` : layer.key
+
+  var body = ''
+  for (const [key, value] of Object.entries(popup.body)) {
+    body += `<p>${key}: ${properties[value]}</p>`
+  }
+
+  return `<div class="smbc-map__item"><div class="smbc-map__item__header__block">${icon}<span class="smbc-map__item__header__block__title">${title}</span></div><div class="smbc-map__item__body">${body}</div></div>`
+}
+
+const getFeatureInfo = (point, layer, bbox, x, y) => {
+  // WMS : GetFeatureInfo
+  var url = `
+  https://spatial.stockport.gov.uk/geoserver/wms?
+  SERVICE=WMS
+  &VERSION=1.1.1
+  &REQUEST=GetFeatureInfo
+  &LAYERS=${layer.layerOptions.layers}
+  &STYLES=
+  &SRS=EPSG:4326
+  &BBOX=${bbox}
+  &WIDTH=${x}
+  &HEIGHT=${y}
+  &QUERY_LAYERS=${layer.layerOptions.layers}
+  &FEATURE_COUNT=50
+  &X=${Math.round(point.x)}
+  &Y=${Math.round(point.y)}
+  &exclude_nodata_result=true
+  &exceptions=application/json
+  &INFO_FORMAT=application/json`
+  
+  return fetch(encodeURI(url.replace(/\s/g,'')))
+  .then(response => response.json())
+  .then(data => data.features !== undefined ? 
+    data.features.map(feature => _popUp(layer, feature.properties)).join('') : '')
+  .catch(error => console.error(error))
+
+  // WFS : GetFeature
+  // (west)lng, (south)lat, (east)lng, (north)lat
+  // e.latlng.lng, e.latlng.lat, e.latlng.lng, e.latlng.lat
+  // var west = (Number.parseFloat(e.latlng.lng) - Number.parseFloat(0.000000001)).toFixed(9)
+  // var south = (Number.parseFloat(e.latlng.lat) - Number.parseFloat(0.000000001)).toFixed(9)
+  // var east = (Number.parseFloat(e.latlng.lng) + Number.parseFloat(0.000000001)).toFixed(9)
+  // var north = (Number.parseFloat(e.latlng.lat) + Number.parseFloat(0.000000001)).toFixed(9)
+  // var bbox = `${west},${south},${east},${north}`
+  // featureInfo = features.map(feature => {
+  //   var url = `
+  //   https://spatial.stockport.gov.uk/geoserver/wfs?
+  //   service=WFS&version=1.1.0
+  //   &request=GetFeature
+  //   &typeName=${feature}
+  //   &outputFormat=application/json
+  //   &srsName=EPSG:4326
+  //   &bbox=${bbox},EPSG:4326
+  //   `
+    
+  //   fetch(encodeURI(url.replace(/\s/g,'')))
+  //   .then(response => response.json())
+  //   .then(data => feature = layer.popup(data.features))
+  // })
+}
+
+const loadLayer = (layerGroup, url, bbox, layerOptions) => {
+  fetch(url.replace('{0}', bbox))
+    .then(response => response.json())
+    .then(data => layerGroup.addLayer(Leaflet.geoJson(data, layerOptions)))
+}
+
+const fetchData = async (url, layerOptions) => {
+  const response = await fetchWithTimeout(url)
+  const body = await response.json()
+  return Leaflet.geoJson(body, layerOptions)
 }
 
 const fetchWithTimeout = (url, options, timeout = 10000) => {
     return Promise.race([
         fetch(url, options),
-        new Promise((resolve, reject) => {
+        new Promise((_, reject) => {
             setTimeout(() => reject(new Error('Timeout')), timeout)
         })
     ])
@@ -143,8 +217,9 @@ const keyByType = (type, options) => {
 const svgElement = svg => `<svg width="18" height="18" class="smbc-control-layers__svg">${svg}</svg>`
 
 export {
+  getFeatureInfo,
+  loadLayer,
   fetchData,
   fetchAddressData,
-  getQueryStringParams,
-  keyByType
+  getQueryStringParams
 }

--- a/src/Layers/index.js
+++ b/src/Layers/index.js
@@ -1,5 +1,5 @@
 import Leaflet from 'leaflet'
-import { fetchData, loadLayer, getFeatureInfo } from '../Helpers'
+import { fetchData, swapLayers, loadLayer, getFeatureInfo } from '../Helpers'
 
 const layersFeatureInfoPopup = async (e, DynamicData, map) => {
   // Is it within the boundary geoJson area...? return
@@ -71,17 +71,14 @@ const reloadDynamicWFSLayers = (wfsLayers, DynamicLayerGroup, map) => {
     var layerGroup = DynamicLayerGroup[layer.key]
     var currentZoom = map.getZoom()
     var visibleAtZoomLevel = (currentZoom >= layer.layerOptions.minZoom && currentZoom <= layer.layerOptions.maxZoom)
-
     if (visibleAtZoomLevel) {
       if (layer.displayInOverlay) {
         var overlay = Leaflet.DomUtil.get(layer.key)
         if (overlay !== null && overlay.checked) {
-          // layerGroup.clearLayers()
-          loadLayer(layerGroup, layer.url, map.getBounds().toBBoxString(), layer.layerOptions)
+          swapLayers(layerGroup, layer.url, map.getBounds().toBBoxString(), layer.layerOptions)
         }
       } else {
-          // layerGroup.clearLayers()
-          loadLayer(layerGroup, layer.url, map.getBounds().toBBoxString(), layer.layerOptions)
+          swapLayers(layerGroup, layer.url, map.getBounds().toBBoxString(), layer.layerOptions)
       }
 
       continue

--- a/src/Layers/index.js
+++ b/src/Layers/index.js
@@ -1,30 +1,98 @@
-import { fetchData } from '../Helpers'
+import Leaflet from 'leaflet'
+import { fetchData, loadLayer, getFeatureInfo } from '../Helpers'
 
-const setDynamicLayers = async (DynamicData, DynamicLayerGroup, WMSLayerGroup, mapRef) => {
-    if (DynamicData !== undefined) {
-        const layers = {}
-        await Promise.all(
-            DynamicData.map(async layer => {
-                if (layer.url.endsWith('wms?')) {
-                    WMSLayerGroup[layer.key] = layer
-                } else {
-                    const url = layer.url.replace(
-                        '{0}',
-                        mapRef.getBounds().toBBoxString()
-                    )
-                    const newLayer = await fetchData(url, layer.layerOptions, mapRef, false)
-                    layers[layer.key] = newLayer
-                }
-            })
-        )
+const layersFeatureInfoPopup = async (e, DynamicData, map) => {
+  // Is it within the boundary geoJson area...? return
 
-        Object.keys(DynamicLayerGroup).map(layer => {
-            DynamicLayerGroup[layer].clearLayers()
-            if (layers[layer] !== undefined && layers[layer] !== null) {
-                DynamicLayerGroup[layer].addLayer(layers[layer])
-            }
-        })
+  var content, featureInfo = '';
+  // IF any Layers - send request for features for each layer in bbox ( tiny )
+  var layersWithFeaturePopup = DynamicData.filter(layer => layer.layerOptions.popup !== undefined)
+  if (layersWithFeaturePopup.length > 0) {
+    for (var x = 0; x < layersWithFeaturePopup.length; x++) {
+      let layer = layersWithFeaturePopup[x]
+      var currentZoom = map.getZoom()
+      var visibleAtZoomLevel = currentZoom >= layer.layerOptions.minZoom && currentZoom <= layer.layerOptions.maxZoom
+      if (!visibleAtZoomLevel) continue
+
+      if (layer.displayInOverlay) { // is toggled on or not in overlays
+        var overlay = Leaflet.DomUtil.get(layer.key)
+        if (overlay !== null && overlay.checked) {
+          var bbox = map.getBounds().toBBoxString() //  get bounds at 12 zoom...
+          featureInfo += await getFeatureInfo(e.containerPoint, layer, bbox, map.getSize().x, map.getSize().y)
+        }
+      } else {
+        var bbox = map.getBounds().toBBoxString()
+        featureInfo += await getFeatureInfo(e.containerPoint, layer, bbox, map.getSize().x, map.getSize().y)
+      }
     }
+  }
+
+  if (featureInfo !== undefined && featureInfo.length > 0) {
+    content = featureInfo
+  } else {
+    // ELSE - just show "no info" generic popup
+    // IF there are layers ( invisible or lower/higher zoom, give advice... )
+    content = '<p>No Information available at this location</p>'
+  }
+
+  // Create one pop up with the different layer info in it
+  // https://leafletjs.com/SlavaUkraini/reference.html#popup-option
+  Leaflet.popup({ keepInView: true, autoPan: true })
+    .setLatLng(e.latlng)
+    .setContent(content)
+    .openOn(map)
 }
 
-export { setDynamicLayers }
+const setDynamicLayers = (DynamicData, DynamicLayerGroup, map) => {
+  for (var x = 0; x < DynamicData.length; x++) {
+    let layer = DynamicData[x]
+    var layerGroup = DynamicLayerGroup[layer.key]
+    var currentZoom = map.getZoom()
+    var visibleAtZoomLevel = (currentZoom >= layer.layerOptions.minZoom && currentZoom <= layer.layerOptions.maxZoom)
+    if (!visibleAtZoomLevel) continue
+
+    if (layer.url.endsWith('wms?')) {
+      layerGroup
+        .addLayer(Leaflet.tileLayer.wms(layer.url, layer.layerOptions))
+        .addTo(map)
+
+      continue
+    }
+
+    loadLayer(layerGroup, layer.url, map.getBounds().toBBoxString(), layer.layerOptions)
+
+    layerGroup.addTo(map)
+  }
+}
+
+const reloadDynamicWFSLayers = (wfsLayers, DynamicLayerGroup, map) => {
+  for (var x = 0; x < wfsLayers.length; x++) {
+    var layer = wfsLayers[x]
+    var layerGroup = DynamicLayerGroup[layer.key]
+    var currentZoom = map.getZoom()
+    var visibleAtZoomLevel = (currentZoom >= layer.layerOptions.minZoom && currentZoom <= layer.layerOptions.maxZoom)
+
+    if (visibleAtZoomLevel) {
+      if (layer.displayInOverlay) {
+        var overlay = Leaflet.DomUtil.get(layer.key)
+        if (overlay !== null && overlay.checked) {
+          // layerGroup.clearLayers()
+          loadLayer(layerGroup, layer.url, map.getBounds().toBBoxString(), layer.layerOptions)
+        }
+      } else {
+          // layerGroup.clearLayers()
+          loadLayer(layerGroup, layer.url, map.getBounds().toBBoxString(), layer.layerOptions)
+      }
+
+      continue
+    }
+
+    layerGroup.clearLayers()
+  }
+}
+
+export {
+  setDynamicLayers,
+  reloadDynamicWFSLayers,
+  layersFeatureInfoPopup
+}


### PR DESCRIPTION
### Description
[Jira Issue: DIGITAL-8174 - SPIKE - WMS request in WebMapping?](https://stockportbi.atlassian.net/browse/DIGITAL-8174)
1) fix min/max zoom
2) Added convenience min/max for all layers in map
3) add max bounds to restrict the map to Stockport only ( can't scroll to Vietnam anymore )
4) enable WMS layers for a map ( **Main Feature** of this PR  )

**./Configuration.ts**
-) At some point we swapped around how we used min/max zoom - So, I added a correction for WMS layers going forward.
-) Added "LayersVisibleFrom" aka Min Zoom ( Leaflet default: "0" => world view ) & "LayersVisibleTo" aka Max Zoom ( Leaflet default: "18" => street view ) to Map object, but this is overridden by layer specific configuration
-) Added default settings ( Stockport boundary ) for Max Bounds of Maps, which can be overridden.

**./App.js**
-) Added maxBounds to Map
-) Changed "setDynamicLayers" to just on start up aka "const SetupControls"
-) Added "reloadDynamicWFSLayers" based on a filter of layers that are not WMS layers
-) Added "layersFeatureInfoPopup" to call the features for the active layers that have popups when the map is clicked

**./Controls**
-) Removed "AddWMSLayers" & "WMSLayerGroup" variable as this is now handled within ./Layers/index.js
-) Added GeoServer.WMS.GetLegendGraphic() call to use the new "Keys" feature within WMS layers

**./Layers**
-) Removed ".map" call from "setDynamicWFSLayers" as this was an anti-pattern, because the returned array was not being used, so replaced with classic for loop, which hopefully makes it easier to read, too.
-) Added "reloadDynamicWFSLayers" which only operates on WFS layers
-) Added "loadLayer" simplified load for WFS layers only ( Which will be phased out as far as I can gather )
-) Added "swapLayers" for WFS layers only, which gets the layers data for the "new" bbox ( map dimensions ) and then clears off the old data and adds the new data.
-) Refactored "fetchAddressData" to use curly brackets like other functions within code base.
-) Refactored "fetchWithTimeout" to use "_" discard inside function that doesn't use the passed parameter


**./Helpers**
-) Added "_popUp" to allow for a simplified popup object being passed from the map config, or handling a slightly altered function, that only requires the "properties" from the requested GeoServer.WMS.GetFeatureInfo() call
-) Added "toLegendOptions" which hold all the possible parameters to pass through to GeoServer.WMS.GetLegendGraphic() call, to configure the key/legend we get back.
-) Added "getFeatureInfo" which uses the above _popUp private method after a successful call to get feature info for layers that have feature info within a clicked location.

**./Configuration/con29-wms**
-) Added "con29-wms" map to "play" with the feature and help visualise the styles being added in GeoServer

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary