### PR TITLE
Feature/nopopup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -110,8 +110,8 @@ function App() {
 
   useEffect(() => {
     var wmsLayersWithPopup = DynamicData.filter(layer => layer.url.endsWith('wms?') && layer.layerOptions.popup !== undefined)
-    if (wmsLayersWithPopup.length > 0) {
-      mapRef.current.on('click', e => layersFeatureInfoPopup(e, wmsLayersWithPopup, mapRef.current))
+    if (wmsLayersWithPopup.length > 0 || Map.NoPopup != undefined) {
+      mapRef.current.on('click', e => layersFeatureInfoPopup(e, wmsLayersWithPopup, mapRef.current, Map.NoPopup))
     }
   }, [mapRef.current])
 

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -128,7 +128,8 @@ export default {
     OnMapClick: Map.OnMapClick,
     OnMapLoad: Map.OnMapLoad,
     HasAllowZoomToLocation: hasAllowZoomToLocationOnLoad,
-    EnableGestureControl: enableGestureControl
+    EnableGestureControl: enableGestureControl,
+    NoPopup: Map.NoPopup
   },
   Tiles: { Token: Tiles.Token },
   LayerControlOptions: Object.assign(defaultLayerControlOptions, LayerControlOptions),

--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -54,8 +54,9 @@ const toLegendOptions = (givenOptions, withoutTitle) => {
   return legendOptionsString
 }
 
-const getFeatureInfo = (point, layer, bbox, x, y) => {
+const getFeatureInfo = (e, layer, bbox, x, y) => {
   // WMS : GetFeatureInfo 
+  var point = e.containerPoint
   var url = `
   https://spatial.stockport.gov.uk/geoserver/wms?
   SERVICE=WMS

--- a/src/Layers/index.js
+++ b/src/Layers/index.js
@@ -1,7 +1,7 @@
 import Leaflet from 'leaflet'
 import { swapLayers, loadLayer, getFeatureInfo } from '../Helpers'
 
-const layersFeatureInfoPopup = async (e, layersWithPopup, map) => {
+const layersFeatureInfoPopup = async (e, layersWithPopup, map, noPopup) => {
   var content, featureResponse, featureInfo = '', layer, overlay
   const currentZoom = map.getZoom()
   const bbox = map.getBounds().toBBoxString()
@@ -17,23 +17,26 @@ const layersFeatureInfoPopup = async (e, layersWithPopup, map) => {
       if (overlay !== null && !overlay.checked) continue
     }
 
-    featureResponse = await getFeatureInfo(e.containerPoint, layer, bbox, x, y)
+    featureResponse = await getFeatureInfo(e, layer, bbox, x, y)
     if (featureResponse !== null) {
       if (featureInfo.length > 0 && index > 0) featureInfo += '<hr>'
-      featureInfo += featureResponse          
+      featureInfo += featureResponse
     }
   }
 
   if (featureInfo !== undefined && featureInfo.length > 0) {
     content = featureInfo
   } else {
-    // ELSE - just show "no info" generic popup
     // IF there are layers ( invisible or lower/higher zoom, give advice... )
     // content = '<p>{layers.length} Layers currently hidden with information at this location.</p>'
     // content += '<p>Turn them on in the top right corner "control box".</p>'
-    // // -or-
-    // content = '<p>No Information available at this location</p>'
-    return
+
+    // ELSE - just show "no info" generic popup
+    if (noPopup) {
+      content = noPopup
+    } else {
+      return
+    }
   }
 
   // Create one pop up with the different layer info in it


### PR DESCRIPTION
### Description
Allow a Map Configuration ( see "tree-reporting" as a working example ) to pass a Map.Nopopup property to display information on a map, when clicked, where a layer is not present or enabled.

To test...

Pull the branch, launch "tree-reporting" from webpack.dev.config and click on the map where a layer is not present ( indicated by colours ).

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary