### PR TITLE
feat(Popup_Fetch): allow extra API call in popup

### DIFF
--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -79,11 +79,29 @@ const getFeatureInfo = (e, layer, bbox, x, y) => {
   return fetch(encodeURI(url.replace(/\s/g,'')))
     .then(response => response.json())
     .then(data => {
-      if (data.features !== undefined && data.features.length > 0) {
-        return data.features.map(feature => _popUp(layer, feature.properties)).join('<hr>')
-      } else {
+
+      // This click event is NOT within a layer space
+      if (data.features === undefined || data.features.length === 0) {
         return null
       }
+
+      // this click event IS on a layer
+      if (layer.layerOptions.popup.fetch === undefined) {
+        return data.features.map(feature => {
+          feature.properties.latlng = e.latlng // add latlng to "properties"
+          return _popUp(layer, feature.properties)
+        }).join('<hr>')
+      }
+
+      // it DOES have an external API call - what data does it need...?
+      return layer.layerOptions.popup.fetch({ latlng: e.latlng })
+        .then((response) => response.json())
+        .then((data) => {
+          return data.features.map(feature => {
+            feature.properties.latlng = e.latlng // add latlng to "properties"
+            return _popUp(layer, feature.properties)
+          }).join('<hr>')
+      })
     })
     .catch(error => console.error(error))
 }


### PR DESCRIPTION
### Description
Allow a popup to contain a "fetch" property which is a fetch API call, then handle the returned data and pass back into the popup HTML properties.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary